### PR TITLE
Build and release PyTorch3D v0.7.6 wheels for Windows using Github action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -34,24 +34,19 @@ jobs:
         run : |
           cp _builder/pixi.toml _builder/pixi.lock ./
 
-      # - name: Uninstall MSVC Compiler of the latest version
-      #   run: |
-      #     Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-      #     $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-      #     $componentsToRemove= @(
-      #         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-      #     )
-      #     [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
-      #     $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-      #     # should be run twice
-      #     $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-      #     $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-
       # CUDA Compiler puts restriction on the MSVC version, so we cannot use
       # the latest version installed by default on the runner.
       #
+      # Here is the list of VS components installed by default on the runner:
+      # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
+      #
       # For components version number see here:
       # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+      #
+      # To get the msvc version that cuda is compatible with, check the CUDA
+      # documentation and/or the host_config.h that comes with CUDA. It will be
+      # available at .pixi\envs\default\include\crt\host_config.h once pixi
+      # environment is installed.
       - name: Install MSVC Compiler v14.39 (Visual Studio 2022 v17.9)
         run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
@@ -84,28 +79,16 @@ jobs:
           locked: true
 
       - name: Build and package PyTorch3D
-        env:
-          # Without this flag, pytorch3d setup.py will determine whether to
-          # build with CUDA support or not based on host system's
-          # pytorch.cuda.is_available(), which would be False on CI runners
-          # without CUDA hardware.
-          FORCE_CUDA: 1
-          # When building on host system without actual GPU, we need to specify
-          # the CUDA architectures to support. See this post:
-          # https://github.com/pytorch/extension-cpp/issues/71#issuecomment-1183674660
-          # Note that the supported archs also depend on the CUDA toolkit
-          # version.
-          TORCH_CUDA_ARCH_LIST: "6.0;6.1;7.0;7.5;8.0;8.6+PTX"
-        run: pixi run python setup.py sdist bdist_wheel
+        run: pixi run build-wheels
 
       - name: Upload as GitHub release
         working-directory: ${{ github.workspace }}/_builder
         shell: bash
         # skip  for now
         run: |
-          gh release create v0.7.6 --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6"
-          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6.tar.gz
-          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6-cp39-cp39-win_amd64.whl
+          gh release create v0.7.6 --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6" --clobber
+          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6.tar.gz --clobber
+          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6-cp39-cp39-win_amd64.whl --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -5,7 +5,8 @@ on:
       - '**'
   push:
     tags:
-      - 'v**'
+      # Run on version tag push like v0.7.6 and v0.7.6-1-py39-cuda116-torch113
+      - 'v*.*.**'
 
 env:
   PT3_VER: 0.7.6
@@ -93,18 +94,13 @@ jobs:
         working-directory: ${{ github.workspace }}/_builder
         shell: bash
         run: |
-
-      - name: Extract Release name from tag or branch
-        id: extract_release_name
-        shell: bash
-        run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             RELEASE="${GITHUB_REF#refs/tags/}"
+            echo "Creating release: $RELEASE"
           else
-            echo "Not tag, so skip creating release.""
+            echo "Not tag, so skip creating release."
             exit 0
           fi
-          echo "Release name: $RELEASE"
           gh release create "$RELEASE" -t "PyTorch3D v$PT3_VER" -n "Prebuilt wheels for PyTorch3D v$PT3_VER"
           cd ../dist
           gh release upload "$RELEASE" pytorch3d-$PT3_VER.tar.gz --clobber

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -34,30 +34,37 @@ jobs:
         run : |
           cp _builder/pixi.toml _builder/pixi.lock ./
 
-      - name: Uninstall MSVC Compiler of the latest version
+      # - name: Uninstall MSVC Compiler of the latest version
+      #   run: |
+      #     Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+      #     $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+      #     $componentsToRemove= @(
+      #         "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+      #     )
+      #     [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
+      #     $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+      #     # should be run twice
+      #     $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+      #     $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
+      # CUDA Compiler puts restriction on the MSVC version, so we cannot use
+      # the latest version installed by default on the runner.
+      #
+      # For components version number see here:
+      # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+      - name: Install MSVC Compiler v14.39 (Visual Studio 2022 v17.9)
         run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
           $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           $componentsToRemove= @(
               "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
           )
-          [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-          # should be run twice
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-
-      - name: Install MSVC Compiler Tools of fixed version
-        run: |
-          # For versions update see here: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
-          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
           $componentsToInstall= @(
               "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
-              "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
           )
-          [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+          [string]$removeArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
+          [string]$addArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"", $removeArgs, $addArgs, '--quiet', '--norestart', '--nocache')
           # should be run twice
           $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
           $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
@@ -80,10 +87,11 @@ jobs:
         env:
           # Without this flag, pytorch3d setup.py will determine whether to
           # build with CUDA support or not based on host system's
-          # pytorch.cuda.is_available().
+          # pytorch.cuda.is_available(), which would be False on CI runners
+          # without CUDA hardware.
           FORCE_CUDA: 1
           # When building on host system without actual GPU, we need to specify
-          # the following. See this post:
+          # the CUDA architectures to support. See this post:
           # https://github.com/pytorch/extension-cpp/issues/71#issuecomment-1183674660
           # Note that the supported archs also depend on the CUDA toolkit
           # version.

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -1,0 +1,54 @@
+name Buid and Release PyTorch3D
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'PyTorch3D version, e.g., 0.7.6'
+        required: false
+        default: '0.7.6'
+
+      cuda_version:
+        description: 'CUDA version, e.g., 11.6'
+        required: false
+        default: '11.6'
+
+run-name: Build and release PyTorch3D v${{ inputs.version }} with CUDA v${{ inputs.cuda_version }} by ${{ github.actor }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+          - runner: windows-latest
+    runs-on: ${{ matrix.config.runner }}
+    steps:
+
+      - name: Checkout PyTorch3D
+        uses: actions/checkout@v4
+        with:
+          repository: facebookresearch/pytorch3d
+          ref: v${{ inputs.version }}
+          fetch-depth: 1
+
+      - name: Checkout builder repository
+        uses: actions/checkout@v4
+        with:
+          path: pixi-builder
+
+      - name: Copy Pixi configuration and lock file
+        run : |
+          cp pixi-builder/pixi.yaml ./
+          cp pixi-builder/pixi.lock ./
+        working-directory: ${{ github.workspace }}
+
+      - name: Install Pixi
+        uses: prefix-dev/setup-pixi@v0.8.0
+        with:
+          pixi-version: v0.29.0
+          cache: true
+          # Enforce lockfile to ensure reproducibility or bail if the lock file
+          # is not up to date.
+          locked: true
+
+      - name: Build and package
+        run: pixi run python setup.py sdist bdist_wheel

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -44,17 +44,16 @@ jobs:
           locked: true
 
       - name: Build and package PyTorch3D
-        run: pixi run python setup.py sdist #bdist_wheel
-
-      #          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6-cp39-cp39-win_amd64.whl --repo urusgraphics/pytorch3d-builder --clobber
+        run: pixi run python setup.py sdist bdist_wheel
 
       - name: Upload as GitHub release
         working-directory: ${{ github.workspace }}/_builder
         shell: bash
         # skip  for now
         run: |
-          gh release create v0.7.6 --repo urusgraphics/pytorch3d-builder --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6"
-          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6.tar.gz --repo urusgraphics/pytorch3d-builder --clobber
+          gh release create v0.7.6 --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6"
+          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6.tar.gz
+          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6-cp39-cp39-win_amd64.whl
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -1,6 +1,8 @@
 name Buid and Release PyTorch3D
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - build-win-wheel
 
 run-name: Build and release PyTorch3D by ${{ github.actor }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -1,18 +1,8 @@
 name Buid and Release PyTorch3D
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'PyTorch3D version, e.g., 0.7.6'
-        required: false
-        default: '0.7.6'
 
-      cuda_version:
-        description: 'CUDA version, e.g., 11.6'
-        required: false
-        default: '11.6'
-
-run-name: Build and release PyTorch3D v${{ inputs.version }} with CUDA v${{ inputs.cuda_version }} by ${{ github.actor }}
+run-name: Build and release PyTorch3D by ${{ github.actor }}
 
 jobs:
   build:

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -34,7 +34,7 @@ jobs:
         run : |
           cp _builder/pixi.toml _builder/pixi.lock ./
 
-      # Ninja help swith parallel compilation
+      # Ninja allow parallel compilation
       - name: Install Ninja
         run: choco install ninja -y
 
@@ -48,6 +48,11 @@ jobs:
           locked: true
 
       - name: Build and package PyTorch3D
+        env:
+          # Without this flag, pytorch3d setup.py will determine whether to
+          # build with CUDA support or not based on host system's
+          # pytorch.cuda.is_available().
+          FORCE_CUDA: 1
         run: pixi run python setup.py sdist bdist_wheel
 
       - name: Upload as GitHub release

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -34,6 +34,35 @@ jobs:
         run : |
           cp _builder/pixi.toml _builder/pixi.lock ./
 
+      - name: Uninstall MSVC Compiler of the latest version
+        run: |
+          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          $componentsToRemove= @(
+              "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+          )
+          [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
+          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+          # should be run twice
+          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
+      - name: Install MSVC Compiler Tools of fixed version
+        run: |
+          # For versions update see here: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+          $componentsToInstall= @(
+              "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
+              "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+          )
+          [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+          # should be run twice
+          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+        shell: powershell
+
       # Ninja allow parallel compilation
       - name: Install Ninja
         run: choco install ninja -y

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: facebookresearch/pytorch3d
-          ref: v${ env.PT3_VER }}
+          ref: v${{ env.PT3_VER }}
           fetch-depth: 1
 
       - name: Checkout builder repository

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -18,8 +18,9 @@ jobs:
       matrix:
         config:
           - runner: windows-latest-l
+    runs-on: ${{ matrix.config.runner }}
 
-
+    steps:
       - name: Checkout PyTorch3D
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -49,9 +49,10 @@ jobs:
       - name: Upload as GitHub release
         working-directory: ${{ github.workspace }}/dist
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ github.TOKEN }}
         # skip pytorch3d-0.7.6-cp39-cp39-win_amd64.whl for now
         run: |
-          gh release upload v0.7.6 pytorch3d-0.7.6.tar.gz --repo urusgraphics/pytorch3d-builder
+          gh release create v0.7.6 --repo urusgraphics/pytorch3d-builder --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6"
+          gh release upload v0.7.6 pytorch3d-0.7.6.tar.gz --repo urusgraphics/pytorch3d-builder --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -1,11 +1,11 @@
 name: Buid and Release PyTorch3D
 on:
-  pull_request:
-    branches:
-      - '**'
   push:
     tags:
-      # Run on version tag push like v0.7.6 and v0.7.6-1-py39-cuda116-torch113
+      # To trigger action, push a tag such as below:
+      #  v0.7.6
+      #  v0.7.6-1-py39-cuda116-torch113
+      #  v0.7.6-test
       - 'v*.*.**'
 
 env:
@@ -88,12 +88,14 @@ jobs:
         shell: bash
         run: |
           pixi run build-wheels
-          ls dist
 
       - name: For tags, create a GitHub release and upload the wheels
         working-directory: ${{ github.workspace }}/_builder
         shell: bash
         run: |
+          Echo "Files in dist:"
+          ls dist
+
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             RELEASE="${GITHUB_REF#refs/tags/}"
             echo "Creating release: $RELEASE"

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         config:
-          - runner: windows-latest
+          - runner: windows-latest-l
+
     runs-on: ${{ matrix.config.runner }}
     steps:
 
@@ -25,12 +26,10 @@ jobs:
       - name: Checkout builder repository
         uses: actions/checkout@v4
         with:
-          path: pixi-builder
+          path: _builder
 
       - name: Copy Pixi configuration and lock file
-        run : |
-          cp pixi-builder/pixi.toml ./
-          cp pixi-builder/pixi.lock ./
+        run : cp _builder/pixi.toml _builder/pixi.lock ./
         working-directory: ${{ github.workspace }}
 
       - name: Install Pixi

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -34,6 +34,10 @@ jobs:
         run : |
           cp _builder/pixi.toml _builder/pixi.lock ./
 
+      # Ninja help swith parallel compilation
+      - name: Install Ninja
+        run: choco install ninja -y
+
       - name: Install Pixi and PyTorch3D dependencies
         uses: prefix-dev/setup-pixi@v0.8.0
         with:

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -1,4 +1,4 @@
-name Buid and Release PyTorch3D
+name: Buid and Release PyTorch3D
 on:
   push:
     branches:

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -34,7 +34,7 @@ jobs:
         run : |
           cp _builder/pixi.toml _builder/pixi.lock ./
 
-      - name: Install Pixi
+      - name: Install Pixi and PyTorch3D dependencies
         uses: prefix-dev/setup-pixi@v0.8.0
         with:
           pixi-version: v0.29.0
@@ -43,5 +43,15 @@ jobs:
           # is not up to date.
           locked: true
 
-      - name: Build and package
-        run: pixi run python setup.py sdist bdist_wheel
+      - name: Build and package PyTorch3D
+        run: pixi run python setup.py sdist #bdist_wheel
+
+      - name: Upload as GitHub release
+        working-directory: ${{ github.workspace }}/dist
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        # skip pytorch3d-0.7.6-cp39-cp39-win_amd64.whl for now
+        run: |
+          gh release upload v0.7.6 pytorch3d-0.7.6.tar.gz
+

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Copy Pixi configuration and lock file
         run : |
-          cp pixi-builder/pixi.yaml ./
+          cp pixi-builder/pixi.toml ./
           cp pixi-builder/pixi.lock ./
         working-directory: ${{ github.workspace }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -94,19 +94,16 @@ jobs:
         shell: bash
         run: |
           Echo "Files in dist:"
-          ls dist
+          ls ../dist
 
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             RELEASE="${GITHUB_REF#refs/tags/}"
             echo "Creating release: $RELEASE"
+            gh release create "$RELEASE" --draft -t "PyTorch3D v$PT3_VER (tag: $RELEASE)" -n "Prebuilt wheels for PyTorch3D v$PT3_VER (tag: $RELEASE)"
+            gh release upload "$RELEASE" ../dist/* --clobber
           else
             echo "Not tag, so skip creating release."
-            exit 0
-          fi
-          gh release create "$RELEASE" -t "PyTorch3D v$PT3_VER" -n "Prebuilt wheels for PyTorch3D v$PT3_VER"
-          cd ../dist
-          gh release upload "$RELEASE" pytorch3d-$PT3_VER.tar.gz --clobber
-          gh release upload "$RELEASE" pytorch3d-$PT3_VER-cp39-cp39-win_amd64.whl --clobber
+            fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -29,8 +29,10 @@ jobs:
           path: _builder
 
       - name: Copy Pixi configuration and lock file
-        run : cp _builder/pixi.toml _builder/pixi.lock ./
+        shell: bash
         working-directory: ${{ github.workspace }}
+        run : |
+          cp _builder/pixi.toml _builder/pixi.lock ./
 
       - name: Install Pixi
         uses: prefix-dev/setup-pixi@v0.8.0

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -3,6 +3,12 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    tags:
+      - 'v**'
+
+env:
+  PT3_VER: 0.7.6
 
 run-name: Build and release PyTorch3D by ${{ github.actor }}
 
@@ -13,14 +19,12 @@ jobs:
         config:
           - runner: windows-latest-l
 
-    runs-on: ${{ matrix.config.runner }}
-    steps:
 
       - name: Checkout PyTorch3D
         uses: actions/checkout@v4
         with:
           repository: facebookresearch/pytorch3d
-          ref: v0.7.6
+          ref: v$PT3_VER
           fetch-depth: 1
 
       - name: Checkout builder repository
@@ -79,16 +83,31 @@ jobs:
           locked: true
 
       - name: Build and package PyTorch3D
-        run: pixi run build-wheels
+        shell: bash
+        run: |
+          pixi run build-wheels
+          ls dist
 
-      - name: Upload as GitHub release
+      - name: For tags, create a GitHub release and upload the wheels
         working-directory: ${{ github.workspace }}/_builder
         shell: bash
-        # skip  for now
         run: |
-          gh release create v0.7.6 --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6" --clobber
-          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6.tar.gz --clobber
-          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6-cp39-cp39-win_amd64.whl --clobber
+
+      - name: Extract Release name from tag or branch
+        id: extract_release_name
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            RELEASE="${GITHUB_REF#refs/tags/}"
+          else
+            echo "Not tag, so skip creating release.""
+            exit 0
+          fi
+          echo "Release name: $RELEASE"
+          gh release create "$RELEASE" -t "PyTorch3D v$PT3_VER" -n "Prebuilt wheels for PyTorch3D v$PT3_VER"
+          cd ../dist
+          gh release upload "$RELEASE" pytorch3d-$PT3_VER.tar.gz --clobber
+          gh release upload "$RELEASE" pytorch3d-$PT3_VER-cp39-cp39-win_amd64.whl --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -53,6 +53,12 @@ jobs:
           # build with CUDA support or not based on host system's
           # pytorch.cuda.is_available().
           FORCE_CUDA: 1
+          # When building on host system without actual GPU, we need to specify
+          # the following. See this post:
+          # https://github.com/pytorch/extension-cpp/issues/71#issuecomment-1183674660
+          # Note that the supported archs also depend on the CUDA toolkit
+          # version.
+          TORCH_CUDA_ARCH_LIST: "6.0;6.1;7.0;7.5;8.0;8.6+PTX"
         run: pixi run python setup.py sdist bdist_wheel
 
       - name: Upload as GitHub release

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -46,13 +46,15 @@ jobs:
       - name: Build and package PyTorch3D
         run: pixi run python setup.py sdist #bdist_wheel
 
+      #          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6-cp39-cp39-win_amd64.whl --repo urusgraphics/pytorch3d-builder --clobber
+
       - name: Upload as GitHub release
-        working-directory: ${{ github.workspace }}/dist
+        working-directory: ${{ github.workspace }}/_builder
         shell: bash
-        # skip pytorch3d-0.7.6-cp39-cp39-win_amd64.whl for now
+        # skip  for now
         run: |
           gh release create v0.7.6 --repo urusgraphics/pytorch3d-builder --title "PyTorch3D v0.7.6" --notes "Prebuilt wheels for PyTorch3D v0.7.6"
-          gh release upload v0.7.6 pytorch3d-0.7.6.tar.gz --repo urusgraphics/pytorch3d-builder --clobber
+          gh release upload v0.7.6 ../dist/pytorch3d-0.7.6.tar.gz --repo urusgraphics/pytorch3d-builder --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -53,5 +53,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.TOKEN }}
         # skip pytorch3d-0.7.6-cp39-cp39-win_amd64.whl for now
         run: |
-          gh release upload v0.7.6 pytorch3d-0.7.6.tar.gz
+          gh release upload v0.7.6 pytorch3d-0.7.6.tar.gz --repo urusgraphics/pytorch3d-builder
 

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: facebookresearch/pytorch3d
-          ref: v${{ inputs.version }}
+          ref: v0.7.6
           fetch-depth: 1
 
       - name: Checkout builder repository

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: facebookresearch/pytorch3d
-          ref: v$PT3_VER
+          ref: v${ env.PT3_VER }}
           fetch-depth: 1
 
       - name: Checkout builder repository

--- a/.github/workflows/build-and-release-pytorch3d.yaml
+++ b/.github/workflows/build-and-release-pytorch3d.yaml
@@ -1,8 +1,8 @@
 name: Buid and Release PyTorch3D
 on:
-  push:
+  pull_request:
     branches:
-      - build-win-wheel
+      - '**'
 
 run-name: Build and release PyTorch3D by ${{ github.actor }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# pixi environments
+.pixi
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # pixi environments
 .pixi
 *.egg-info

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 
 This repositoary exists to build and release precompiled pytorch3d wheels for
 platforms where precompiled pytorch3d packages are not available.
+
+To test build PyTorch3D with the provided Pixi configuration locally, adapt the
+following snippets as appropriate:
+
+    git clone https://github.com/facebookresearch/pytorch3d.git -b v0.7.6
+    cp pixi.lock pixi.toml pytorch3d
+    cd pytorch3d
+    pixi install --locked
+    pixi run python sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repositoary exists to build and release precompiled pytorch3d wheels for
 platforms where precompiled pytorch3d packages are not available.
 
 To test build PyTorch3D with the provided Pixi configuration locally, adapt the
-following snippets as appropriate:
+following snippets (refer the the GitHub action script) as appropriate:
 
     git clone https://github.com/facebookresearch/pytorch3d.git -b v0.7.6
     cp pixi.lock pixi.toml pytorch3d
     cd pytorch3d
     pixi install --locked
-    pixi run python sdist bdist_wheel
+    pixi run build-wheels

--- a/pixi.lock
+++ b/pixi.lock
@@ -117,7 +117,7 @@ environments:
       - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnvjpeg-dev-11.6.2.124-hb5906b9_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-h4852527_1.conda
@@ -247,7 +247,7 @@ environments:
       - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnpp-dev-11.6.3.124-0.tar.bz2
       - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnvjpeg-11.6.2.124-0.tar.bz2
       - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnvjpeg-dev-11.6.2.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.0-hf8721a0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
@@ -2798,36 +2798,37 @@ packages:
   timestamp: 1707101388552
 - kind: conda
   name: libpng
-  version: 1.6.43
-  build: h19919ed_0
+  version: 1.6.44
+  build: h3ca93ac_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
-  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
-  md5: 77e398acc32617a0384553aea29e866b
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
   depends:
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
   purls: []
-  size: 347514
-  timestamp: 1708780763195
+  size: 348933
+  timestamp: 1726235196095
 - kind: conda
   name: libpng
-  version: 1.6.43
-  build: h2797004_0
+  version: 1.6.44
+  build: hadc24fc_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
-  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.44-hadc24fc_0.conda
+  sha256: e5b14f7a01c2db4362d8591f42f82f336ed48d5e4079e4d1f65d0c2a3637ea78
+  md5: f4cc49d7aa68316213e4b12be35308d1
   depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 288221
-  timestamp: 1708780443939
+  size: 290661
+  timestamp: 1726234747153
 - kind: conda
   name: libsqlite
   version: 3.46.1

--- a/pixi.lock
+++ b/pixi.lock
@@ -2,127 +2,150 @@ version: 5
 environments:
   default:
     channels:
-    - url: https://conda.anaconda.org/pytorch/
+    - url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/
     - url: https://conda.anaconda.org/nvidia/
-    - url: https://conda.anaconda.org/iopath/
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/pytorch/
+    - url: https://conda.anaconda.org/iopath/
     indexes:
     - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.5.0-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.121-mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-21_linux64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py39hf88036b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py39h15c3d72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py39h15c3d72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl-11.6.55-hf6102b2_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-command-line-tools-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-compiler-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.6.55-he381448_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-11.6.55-h42ad0f4_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cuobjdump-11.6.124-h2eeebcb_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.6.124-h86345e5_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cuxxfilt-11.6.124-hecbf4f6_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-driver-dev-11.6.55-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-gdb-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-dev-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-memcheck-11.8.86-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-compute-12.4.1-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-11.6.124-hbba6d2d_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvdisasm-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-11.6.55-haa9ef22_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprof-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprune-11.6.124-he22ec0a_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.6.124-h020bade_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-dev-11.6.124-h249d397_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.6.124-h0630a44_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvp-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-samples-11.6.101-h8efea70_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-toolkit-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-tools-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-visual-tools-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cccl-11.6.55-hf6102b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-command-line-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-compiler-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cudart-11.6.55-he381448_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cudart-dev-11.6.55-h42ad0f4_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cuobjdump-11.6.124-h2eeebcb_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cupti-11.6.124-h86345e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cuxxfilt-11.6.124-hecbf4f6_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-driver-dev-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-gdb-11.6.124-hcdc6958_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-libraries-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-libraries-dev-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-memcheck-11.6.124-ha4ac6c0_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nsight-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nsight-compute-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvcc-11.6.124-hbba6d2d_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvdisasm-11.6.124-h75ac146_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvml-dev-11.6.55-haa9ef22_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvprof-11.6.124-h7c7a4e2_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvprune-11.6.124-he22ec0a_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvrtc-11.6.124-h020bade_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvrtc-dev-11.6.124-h249d397_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvtx-11.6.124-h0630a44_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvvp-11.6.124-h38ac01c_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-runtime-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-samples-11.6.101-h8efea70_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-sanitizer-api-11.6.124-h3d04c53_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-toolkit-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-visual-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-5.1.2-gpl_h8dda1f0_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fvcore-0.1.5.post20221221-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/gds-tools-1.9.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/gds-tools-1.2.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_mkl.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcublas-12.4.5.8-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcublas-dev-12.4.5.8-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufft-11.2.1.3-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufft-dev-11.2.1.3-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.9.1.3-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.9.1.3-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.5.147-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.3.5.147-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.6.1.9-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusolver-dev-11.6.1.9-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusparse-12.3.1.170-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusparse-dev-12.3.1.170-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcublas-11.9.2.110-h5e84587_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcublas-dev-11.9.2.110-h5c901ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufft-10.7.2.124-h4fbf590_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufft-dev-10.7.2.124-h98a8f43_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufile-1.2.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufile-dev-1.2.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcurand-10.2.9.124-h37c27f7_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcurand-dev-10.2.9.124-h54cfa4b_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusolver-11.3.4.124-h33c3c4e_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusolver-dev-11.3.4.124-h203c794_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusparse-11.7.2.124-h7538f96_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusparse-dev-11.7.2.124-hbbe9722_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.1.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_mkl.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libnpp-12.2.5.30-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libnpp-dev-12.2.5.30-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnpp-11.6.3.124-hd2722f0_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnpp-dev-11.6.3.124-h3c42840_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-12.3.1.117-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnvjpeg-11.6.2.124-hd473ad6_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnvjpeg-dev-11.6.2.124-hb5906b9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.18.0-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.11.0-h9c3ff4c_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.7-ha31de31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.8-hf5423f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.0.0-ha957f24_49657.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2024.0.0-ha770c72_49657.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2024.0.0-ha957f24_49657.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/linux-64/nsight-compute-2024.1.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/nsight-compute-2022.1.1.2-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.3.1-hcb278e6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-2.10.1-py39hf3d152e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
@@ -131,67 +154,70 @@ environments:
       - conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-1.13.1-py3.9_cuda11.6_cudnn8.3.2_0.tar.bz2
       - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-cuda-11.6-h867d48c_0.tar.bz2
       - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py39h8cd3c5a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h84d6215_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.4.1-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/pytorch/linux-64/torchvision-0.14.1-py39_cu116.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/yacs-0.1.8-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py39h08a7858_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/blas-1.0-mkl.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py39ha51f57c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.0-py39ha55e580_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py39ha55e580_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cccl-11.6.55-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-command-line-tools-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-compiler-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-11.6.55-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-dev-11.6.55-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cuobjdump-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cupti-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cuxxfilt-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-dev-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-memcheck-11.8.86-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nsight-compute-12.4.1-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvcc-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvdisasm-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvml-dev-11.6.55-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvprof-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvprune-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-dev-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvtx-11.6.124-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvvp-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-runtime-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-toolkit-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-tools-11.6.2-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-visual-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cccl-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-command-line-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-compiler-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cudart-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cudart-dev-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cuobjdump-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cupti-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cuxxfilt-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-libraries-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-libraries-dev-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-memcheck-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nsight-compute-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvcc-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvdisasm-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvml-dev-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvprof-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvprune-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvrtc-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvrtc-dev-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvtx-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvvp-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-runtime-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-sanitizer-api-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-toolkit-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-visual-tools-11.6.2-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fvcore-0.1.5.post20221221-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
@@ -202,25 +228,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-1_h8933c1f_netlib.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-5_hd5c7e75_netlib.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcublas-12.4.5.8-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcublas-dev-12.4.5.8-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcufft-11.2.1.3-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcufft-dev-11.2.1.3-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcurand-10.3.5.147-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcurand-dev-10.3.5.147-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusolver-11.6.1.9-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusolver-dev-11.6.1.9-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusparse-12.3.1.170-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libcusparse-dev-12.3.1.170-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcublas-11.9.2.110-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcublas-dev-11.9.2.110-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcufft-10.7.2.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcufft-dev-10.7.2.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcurand-10.2.9.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcurand-dev-10.2.9.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusolver-11.3.4.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusolver-dev-11.3.4.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusparse-11.7.2.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusparse-dev-11.7.2.124-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.17-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-5_hd5c7e75_netlib.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnpp-12.2.5.30-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnpp-dev-12.2.5.30-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-12.3.1.117-0.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnpp-11.6.3.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnpp-dev-11.6.3.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnvjpeg-11.6.2.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnvjpeg-dev-11.6.2.124-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.0-hf8721a0_2.conda
@@ -236,13 +262,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49658.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-      - conda: https://conda.anaconda.org/nvidia/win-64/nsight-compute-2024.1.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/nsight-compute-2022.1.1.2-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py39hddb5d58_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-ha2aaf27_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-9.4.0-py39hcebd2be_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-2.10.1-py39hcbf5309_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
@@ -252,16 +277,11 @@ environments:
       - conda: https://conda.anaconda.org/pytorch/win-64/pytorch-1.13.1-py3.9_cuda11.6_cudnn8_0.tar.bz2
       - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-cuda-11.6-h867d48c_0.tar.bz2
       - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py39h99910a6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py39ha55e580_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/pytorch/win-64/torchvision-0.14.1-py39_cu116.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
@@ -274,11 +294,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/yacs-0.1.8-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py39h9bf74da_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+      - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/f7/24d8ed4fd9c43b90354df7764f81f0dd5e623f9a50f1538f90fe085d6dff/pywin32-306-cp39-cp39-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl
 packages:
 - kind: conda
   name: _libgcc_mutex
@@ -309,6 +331,22 @@ packages:
   purls: []
   size: 5744
   timestamp: 1650742457817
+- kind: conda
+  name: aom
+  version: 3.5.0
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.5.0-h27087fc_0.tar.bz2
+  sha256: ed05f72ffa891e3c6a507eac6f0221c85c1f0611491328cd098308060740891c
+  md5: a08150fd2298460cd1fcccf626305642
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 2859124
+  timestamp: 1663808526544
 - kind: conda
   name: blas
   version: '1.0'
@@ -496,13 +534,12 @@ packages:
   timestamp: 1725278204397
 - kind: conda
   name: cffi
-  version: 1.17.0
-  build: py39h15c3d72_1
-  build_number: 1
+  version: 1.17.1
+  build: py39h15c3d72_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py39h15c3d72_1.conda
-  sha256: aaed3ce34c340b2cd1adbcb0a42ad5ad331f4103854b03c48d245e951138daa7
-  md5: 26236d9306b1a33b079df356ad4d07ee
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py39h15c3d72_0.conda
+  sha256: f24486fdb31df2a7b04555093fdcbb3a314a1f29a4906b72ac9010906eb57ff8
+  md5: 7e61b8777f42e00b08ff059f9e8ebc44
   depends:
   - __glibc >=2.17,<3.0.a0
   - libffi >=3.4,<4.0a0
@@ -511,20 +548,18 @@ packages:
   - python >=3.9,<3.10.0a0
   - python_abi 3.9.* *_cp39
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/cffi?source=hash-mapping
-  size: 241429
-  timestamp: 1724956418269
+  size: 241610
+  timestamp: 1725571230934
 - kind: conda
   name: cffi
-  version: 1.17.0
-  build: py39ha55e580_1
-  build_number: 1
+  version: 1.17.1
+  build: py39ha55e580_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.0-py39ha55e580_1.conda
-  sha256: ddcf4b3e61040b3ea729bec42e70f7771e4937fdd6624d7df49e3b3556e3ecc3
-  md5: 6dae6d38cce8d9cd6119b117ac0b12de
+  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py39ha55e580_0.conda
+  sha256: 9cbef6685015cef22b8f09fef6be4217018964af692251c980b5af23a28afc76
+  md5: 1e0c1867544dc5f3adfad28742f4d983
   depends:
   - pycparser
   - python >=3.9,<3.10.0a0
@@ -533,11 +568,10 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/cffi?source=hash-mapping
-  size: 238269
-  timestamp: 1724956856273
+  size: 236935
+  timestamp: 1725561195746
 - kind: conda
   name: charset-normalizer
   version: 3.3.2
@@ -555,34 +589,24 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 46597
   timestamp: 1698833765762
-- kind: conda
+- kind: pypi
   name: colorama
   version: 0.4.6
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  md5: 3faab06a954c2a04039983f2c4a50d99
-  depends:
-  - python >=3.7
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/colorama?source=hash-mapping
-  size: 25170
-  timestamp: 1666700778190
+  url: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+  sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+  requires_python: '!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7'
 - kind: conda
   name: cuda
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-11.6.2-0.tar.bz2
-  sha256: 1cee96abb344171436bdb6d6509943802164c2318a72039534f842153a45a398
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-11.6.2-0.tar.bz2
   md5: af5c0a4642b14e93d4c48aaa1076a6ba
   depends:
   - cuda-runtime >=11.6.2
   - cuda-toolkit >=11.6.2
+  arch: x86_64
+  platform: linux
   size: 1435
   timestamp: 1656529490851
 - kind: conda
@@ -590,12 +614,13 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-11.6.2-0.tar.bz2
-  sha256: 5a5219dcc29a97b17b31c42b277e617e5f1a1abe41915f8ede7be2579818cb76
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-11.6.2-0.tar.bz2
   md5: c6c91c7b68c7794e2b65715ac4a69479
   depends:
   - cuda-runtime >=11.6.2
   - cuda-toolkit >=11.6.2
+  arch: x86_64
+  platform: win
   size: 1301
   timestamp: 1657842551707
 - kind: conda
@@ -603,9 +628,10 @@ packages:
   version: 11.6.55
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cccl-11.6.55-0.tar.bz2
-  sha256: 220d6f0453f14c62bb275353aa101c4944d35db92b0872d60d1d6dcd4bae02c8
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cccl-11.6.55-0.tar.bz2
   md5: cb596fbe733e13949ccf6971b14f4fc9
+  arch: x86_64
+  platform: win
   size: 1233766
   timestamp: 1656445622469
 - kind: conda
@@ -613,9 +639,10 @@ packages:
   version: 11.6.55
   build: hf6102b2_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl-11.6.55-hf6102b2_0.tar.bz2
-  sha256: 3d4982f613e449dcd890af09a47c21ed4eefd08214a210dbf375578a3b9b6bc3
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cccl-11.6.55-hf6102b2_0.tar.bz2
   md5: 6472e4cb22cdf59544d4fba86be2ec82
+  arch: x86_64
+  platform: linux
   size: 1217359
   timestamp: 1646161775316
 - kind: conda
@@ -623,8 +650,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-command-line-tools-11.6.2-0.tar.bz2
-  sha256: 737026b73d3163980e151b88944e43ad9390a56593a6b0e45ad275c3e8dede86
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-command-line-tools-11.6.2-0.tar.bz2
   md5: b972c648560f14c72c61b57560b821cd
   depends:
   - cuda-cupti >=11.6.124
@@ -634,6 +660,8 @@ packages:
   - cuda-nvprof >=11.6.124
   - cuda-nvtx >=11.6.124
   - cuda-sanitizer-api >=11.6.124
+  arch: x86_64
+  platform: linux
   size: 1475
   timestamp: 1656529349293
 - kind: conda
@@ -641,8 +669,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-command-line-tools-11.6.2-0.tar.bz2
-  sha256: 533af2473c24f0bd975d56a705d69523a100e1304a6e1097059edc7e36c9c3a7
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-command-line-tools-11.6.2-0.tar.bz2
   md5: 585326c70cce98c204c32e4ccf5e7225
   depends:
   - cuda-cupti >=11.6.124
@@ -651,6 +678,8 @@ packages:
   - cuda-nvprof >=11.6.124
   - cuda-nvtx >=11.6.124
   - cuda-sanitizer-api >=11.6.124
+  arch: x86_64
+  platform: win
   size: 1345
   timestamp: 1657842430005
 - kind: conda
@@ -658,14 +687,15 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-compiler-11.6.2-0.tar.bz2
-  sha256: 17b1d20faacf634d7b7cf710a5be7863264c8cf74043bcb6a07c5d1d2ec11667
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-compiler-11.6.2-0.tar.bz2
   md5: 31dd92e37e9bfa1f2158fbd60228f510
   depends:
   - cuda-cuobjdump >=11.6.124
   - cuda-cuxxfilt >=11.6.124
   - cuda-nvcc >=11.6.124
   - cuda-nvprune >=11.6.124
+  arch: x86_64
+  platform: linux
   size: 1462
   timestamp: 1656529360983
 - kind: conda
@@ -673,14 +703,15 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-compiler-11.6.2-0.tar.bz2
-  sha256: 953663b46d172a93a37df855ed63c1e0de2b1e364457ae7efeb8c2e4f1ea6aad
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-compiler-11.6.2-0.tar.bz2
   md5: 0fe3bdd59239873f18b24ca8ee07630e
   depends:
   - cuda-cuobjdump >=11.6.124
   - cuda-cuxxfilt >=11.6.124
   - cuda-nvcc >=11.6.124
   - cuda-nvprune >=11.6.124
+  arch: x86_64
+  platform: win
   size: 1329
   timestamp: 1657842441070
 - kind: conda
@@ -688,9 +719,10 @@ packages:
   version: 11.6.55
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-11.6.55-0.tar.bz2
-  sha256: 30801d86f54c5edda04189eee123ff4d07f7d31f1bce71a76be92c9ab0fb61dd
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cudart-11.6.55-0.tar.bz2
   md5: 347b92a621d34ac5689621b17d8b2555
+  arch: x86_64
+  platform: win
   size: 1507570
   timestamp: 1657571025013
 - kind: conda
@@ -698,9 +730,10 @@ packages:
   version: 11.6.55
   build: he381448_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.6.55-he381448_0.tar.bz2
-  sha256: 4d2d29cb3bed7c33d32403f06452ef4b0023d586443c710845c326cb0d66cef0
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cudart-11.6.55-he381448_0.tar.bz2
   md5: 1d656e60710e5b25778e33b380e478e9
+  arch: x86_64
+  platform: linux
   size: 198348
   timestamp: 1639795847364
 - kind: conda
@@ -708,12 +741,13 @@ packages:
   version: 11.6.55
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-dev-11.6.55-0.tar.bz2
-  sha256: 27fd441f3ede0fa49f59b7f28618e57ea51e96e8f0e4de43fd0f0d1443096b95
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cudart-dev-11.6.55-0.tar.bz2
   md5: 1ab6ddbb686c76251f6a644c2b1c8001
   depends:
   - cuda-cccl
   - cuda-cudart >=11.6.55
+  arch: x86_64
+  platform: win
   size: 688234
   timestamp: 1657571077840
 - kind: conda
@@ -721,12 +755,13 @@ packages:
   version: 11.6.55
   build: h42ad0f4_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-11.6.55-h42ad0f4_0.tar.bz2
-  sha256: aad603c802c14daf5b97d9eec042a6cd7c50675c0a22b50744387877c39b72d4
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cudart-dev-11.6.55-h42ad0f4_0.tar.bz2
   md5: 315b5b998a6b75e89de63279afea28f8
   depends:
   - cuda-cccl
   - cuda-cudart >=11.6.55
+  arch: x86_64
+  platform: linux
   size: 1064044
   timestamp: 1639795848386
 - kind: conda
@@ -734,9 +769,10 @@ packages:
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cuobjdump-11.6.124-0.tar.bz2
-  sha256: 87b66408e5225368911e3cd06cc9b23b701ea44a6acb5a17e01d1dc6c32f4eb2
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cuobjdump-11.6.124-0.tar.bz2
   md5: a4b568d86f310406b15f343f05e62ff0
+  arch: x86_64
+  platform: win
   size: 2606856
   timestamp: 1656529869765
 - kind: conda
@@ -744,9 +780,10 @@ packages:
   version: 11.6.124
   build: h2eeebcb_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cuobjdump-11.6.124-h2eeebcb_0.tar.bz2
-  sha256: bc03e2e64b56c52880801afc8fcb394ac07c3bafcd3f3c9ddbfd156b4c7de0ba
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cuobjdump-11.6.124-h2eeebcb_0.tar.bz2
   md5: 5fef1e10de86c8f33bee28bb59d43c9c
+  arch: x86_64
+  platform: linux
   size: 137528
   timestamp: 1646799366613
 - kind: conda
@@ -754,9 +791,10 @@ packages:
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cupti-11.6.124-0.tar.bz2
-  sha256: 635d4c6dbf5fc0053792c7f11b9ff61b32aa9c574e50f49aa275101ed16e06c4
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cupti-11.6.124-0.tar.bz2
   md5: 5589c69dd83b78cbfd050f179584a457
+  arch: x86_64
+  platform: win
   size: 10501677
   timestamp: 1657823921791
 - kind: conda
@@ -764,9 +802,10 @@ packages:
   version: 11.6.124
   build: h86345e5_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.6.124-h86345e5_0.tar.bz2
-  sha256: 989d85df8eb6bf2e2a8c42b9dac456841a9a109547c0ad670e0de7b785239483
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cupti-11.6.124-h86345e5_0.tar.bz2
   md5: 53238c87653898e83b6cd0f072fafec7
+  arch: x86_64
+  platform: linux
   size: 23210814
   timestamp: 1646800069888
 - kind: conda
@@ -774,9 +813,10 @@ packages:
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-cuxxfilt-11.6.124-0.tar.bz2
-  sha256: 193dd4e19b38fe7bafc7399a53a530316f136188e542c152803fc45d9efbc727
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-cuxxfilt-11.6.124-0.tar.bz2
   md5: 42dac2069ecaac20121470efe9a3580f
+  arch: x86_64
+  platform: win
   size: 169057
   timestamp: 1657835994062
 - kind: conda
@@ -784,9 +824,10 @@ packages:
   version: 11.6.124
   build: hecbf4f6_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cuxxfilt-11.6.124-hecbf4f6_0.tar.bz2
-  sha256: 82987f062af4005715850444598f3dde2d59775c818c896dd3a7017840e382f3
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-cuxxfilt-11.6.124-hecbf4f6_0.tar.bz2
   md5: 10d374991b52d605a36f194997fe44b6
+  arch: x86_64
+  platform: linux
   size: 289994
   timestamp: 1646796211378
 - kind: conda
@@ -794,28 +835,29 @@ packages:
   version: 11.6.55
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-driver-dev-11.6.55-0.tar.bz2
-  sha256: 6674d114ba0f80eb33db7a4a15c53be07528b49bcb78dfa7da05e3b00a765bd9
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-driver-dev-11.6.55-0.tar.bz2
   md5: 6fea0593b9fdb4b7ad15817594134d21
+  arch: x86_64
+  platform: linux
   size: 16838
   timestamp: 1639795847941
 - kind: conda
   name: cuda-gdb
-  version: 12.4.127
-  build: '0'
+  version: 11.6.124
+  build: hcdc6958_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-gdb-12.4.127-0.tar.bz2
-  sha256: b66f62901a846328bf999be246098ff9dc07fb098b089fe995cc7a6b7b0eb664
-  md5: f36a1e5fef08c9980991e3ed27fcd644
-  size: 6056326
-  timestamp: 1710546537965
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-gdb-11.6.124-hcdc6958_0.tar.bz2
+  md5: d7fdd4c2c8d11fdf544af1f27a927423
+  arch: x86_64
+  platform: linux
+  size: 4978333
+  timestamp: 1646799043982
 - kind: conda
   name: cuda-libraries
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.6.2-0.tar.bz2
-  sha256: 6315f9f074d2e8fb7dfa6a1833c96db524430b69cf64dfff393cff0ab1560b06
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-libraries-11.6.2-0.tar.bz2
   md5: abfbf487c341ae21cfbb62e6606d96c6
   depends:
   - cuda-cudart >=11.6.55
@@ -828,6 +870,8 @@ packages:
   - libcusparse >=11.7.2.124
   - libnpp >=11.6.3.124
   - libnvjpeg >=11.6.2.124
+  arch: x86_64
+  platform: linux
   size: 1540
   timestamp: 1656529373038
 - kind: conda
@@ -835,8 +879,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-11.6.2-0.tar.bz2
-  sha256: ec5089b875d027fec2732a2257d9ce8c4574d9b8d4528877ea32e018aa45cd2a
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-libraries-11.6.2-0.tar.bz2
   md5: 57b8a01ffc3dae55e3a5f9d9d8ee0b78
   depends:
   - cuda-cudart >=11.6.55
@@ -848,6 +891,8 @@ packages:
   - libcusparse >=11.7.2.124
   - libnpp >=11.6.3.124
   - libnvjpeg >=11.6.2.124
+  arch: x86_64
+  platform: win
   size: 1366
   timestamp: 1657842452324
 - kind: conda
@@ -855,8 +900,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-dev-11.6.2-0.tar.bz2
-  sha256: abcf5ae7332ece32e3487e4c30881ad76d55c8198cd7b0dabac11edf6655754c
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-libraries-dev-11.6.2-0.tar.bz2
   md5: 70a3d479be7ab1a743564b991a1adbe3
   depends:
   - cuda-cccl >=11.6.55
@@ -871,6 +915,8 @@ packages:
   - libcusparse-dev >=11.7.2.124
   - libnpp-dev >=11.6.3.124
   - libnvjpeg-dev >=11.6.2.124
+  arch: x86_64
+  platform: linux
   size: 1538
   timestamp: 1656529385483
 - kind: conda
@@ -878,8 +924,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-dev-11.6.2-0.tar.bz2
-  sha256: 02c49b4a03e37fba0aacc0651fdf80e68367f7c06de4ef2145fbe6d1da89dd6a
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-libraries-dev-11.6.2-0.tar.bz2
   md5: a3b1559098066232c5ee3bd07fb6faf5
   depends:
   - cuda-cccl >=11.6.55
@@ -892,70 +937,78 @@ packages:
   - libcusparse-dev >=11.7.2.124
   - libnpp-dev >=11.6.3.124
   - libnvjpeg-dev >=11.6.2.124
+  arch: x86_64
+  platform: win
   size: 1389
   timestamp: 1657842463980
 - kind: conda
   name: cuda-memcheck
-  version: 11.8.86
+  version: 11.6.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-memcheck-11.8.86-0.tar.bz2
-  sha256: f8c3684e78956815a07411b78eb8b7a26b9778dbcd3c03376ae0fc66cec85e81
-  md5: 0d658b7c0e0799af3a981eff1c33771c
-  size: 171911
-  timestamp: 1661470265954
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-memcheck-11.6.124-0.tar.bz2
+  md5: ee7af7b26009a3a1b265aa3443e5261c
+  arch: x86_64
+  platform: win
+  size: 187058
+  timestamp: 1656443820526
 - kind: conda
   name: cuda-memcheck
-  version: 11.8.86
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-memcheck-11.8.86-0.tar.bz2
-  sha256: 0386ac65caee745ebe864e89b62a2efe7f4af7feeb452d349435bb81c6cc2757
-  md5: af2ac23440715e346977009696c60c5e
-  size: 187077
-  timestamp: 1661486161008
+  version: 11.6.124
+  build: ha4ac6c0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-memcheck-11.6.124-ha4ac6c0_0.tar.bz2
+  md5: f2ec4be8d93788ce07013125feca2482
+  arch: x86_64
+  platform: linux
+  size: 172926
+  timestamp: 1646798619985
 - kind: conda
   name: cuda-nsight
-  version: 12.4.127
+  version: 11.6.124
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-12.4.127-0.tar.bz2
-  sha256: 809499163a96812af3a2a4058cdf7affc1c638eabf255e6f39efdcd75a67f3eb
-  md5: 031e25cc0010cecfa62249acc3939ee6
-  size: 119222580
-  timestamp: 1710541146699
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nsight-11.6.124-0.tar.bz2
+  md5: fbe02107d2544cc9df3bf89fcd6c2304
+  arch: x86_64
+  platform: linux
+  size: 119137472
+  timestamp: 1655354639192
 - kind: conda
   name: cuda-nsight-compute
-  version: 12.4.1
+  version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-compute-12.4.1-0.tar.bz2
-  sha256: 669cd54c2cca10d3c47c5ed1ca9d9d0fce03c081bbc8af2ba695f1f589284ea7
-  md5: 72b772f260afa08d99ef2fd15f035739
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nsight-compute-11.6.2-0.tar.bz2
+  md5: 8b0ab676275bb543531df27e7a38a1b0
   depends:
-  - nsight-compute >=2024.1.1.4
-  size: 1847
-  timestamp: 1711654532367
+  - nsight-compute >=2022.1.1.2
+  arch: x86_64
+  platform: linux
+  size: 1430
+  timestamp: 1656529397179
 - kind: conda
   name: cuda-nsight-compute
-  version: 12.4.1
+  version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nsight-compute-12.4.1-0.tar.bz2
-  sha256: bf2a7a81ab4cffb06bc29412f6673ac6055993c8126f252f863e45dde30b11ea
-  md5: c0c780a71011d05c3e40f44f7606656d
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nsight-compute-11.6.2-0.tar.bz2
+  md5: c6c56fafb7e5c9a5915c04dcdf42547f
   depends:
-  - nsight-compute >=2024.1.1.4
-  size: 1769
-  timestamp: 1711654698530
+  - nsight-compute >=2022.1.1.2
+  arch: x86_64
+  platform: win
+  size: 1305
+  timestamp: 1657842474758
 - kind: conda
   name: cuda-nvcc
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvcc-11.6.124-0.tar.bz2
-  sha256: 465baefb281150e29452a6cec1b295e4ad550132369c171a6e8d3aa10aece2f5
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvcc-11.6.124-0.tar.bz2
   md5: e1934c1e58959b76af20771558153b4d
+  arch: x86_64
+  platform: win
   size: 45500858
   timestamp: 1657836312614
 - kind: conda
@@ -963,39 +1016,43 @@ packages:
   version: 11.6.124
   build: hbba6d2d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-11.6.124-hbba6d2d_0.tar.bz2
-  sha256: b15a978e93e8b4a1f51b9cb52fdf9cf36c15471e7fd7817356917dfeb15e29fa
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvcc-11.6.124-hbba6d2d_0.tar.bz2
   md5: b43d7b24ed402cdd5e4c1c1238645768
+  arch: x86_64
+  platform: linux
   size: 44292444
   timestamp: 1646799612290
 - kind: conda
   name: cuda-nvdisasm
-  version: 12.4.127
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvdisasm-12.4.127-0.tar.bz2
-  sha256: 2635c44a557ab45c46265e9af7694d00956f6bd8c031d5a10da83e6472d26aae
-  md5: 2011077477fc67866170f04bcac0dcd0
-  size: 50215513
-  timestamp: 1710544140559
-- kind: conda
-  name: cuda-nvdisasm
-  version: 12.4.127
+  version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvdisasm-12.4.127-0.tar.bz2
-  sha256: 58d9cebf5f70d1dcc41fdc14150ffe045bd0ec6b1e5f91ef5a8cd0a1395d3590
-  md5: 3a90f35980872cb4fd34d7a5abba6dbe
-  size: 50383331
-  timestamp: 1710545430171
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvdisasm-11.6.124-0.tar.bz2
+  md5: 9d4436bd8ae622d491adc2df40efb6d0
+  arch: x86_64
+  platform: win
+  size: 33164983
+  timestamp: 1656531579570
+- kind: conda
+  name: cuda-nvdisasm
+  version: 11.6.124
+  build: h75ac146_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvdisasm-11.6.124-h75ac146_0.tar.bz2
+  md5: e552922f8627eb473ea15d48d323e2dd
+  arch: x86_64
+  platform: linux
+  size: 33037383
+  timestamp: 1646800190645
 - kind: conda
   name: cuda-nvml-dev
   version: 11.6.55
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvml-dev-11.6.55-0.tar.bz2
-  sha256: aed64eba589e337fb819adc5e9e2b61c40fb455761efeb0a705a897c707da904
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvml-dev-11.6.55-0.tar.bz2
   md5: c6457481b5431e4b20179950a2136e46
+  arch: x86_64
+  platform: win
   size: 85009
   timestamp: 1657833217709
 - kind: conda
@@ -1003,39 +1060,43 @@ packages:
   version: 11.6.55
   build: haa9ef22_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-11.6.55-haa9ef22_0.tar.bz2
-  sha256: 404defa489fe2e95ef620b9746aae4bbb49e21a07a796322c6c362b76dcc904f
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvml-dev-11.6.55-haa9ef22_0.tar.bz2
   md5: 46f4a1cdf2fb9a21dc4f1abe51c4df5c
+  arch: x86_64
+  platform: linux
   size: 66704
   timestamp: 1639797040268
 - kind: conda
   name: cuda-nvprof
-  version: 12.4.127
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprof-12.4.127-0.tar.bz2
-  sha256: 75597b69222f52c0de92e72f0431b133a2ac6945dc3456f3a4c2c9da4681f0f3
-  md5: bfdbdb5a65e35ef10ca14723de7fd9b5
-  size: 4960988
-  timestamp: 1710549514085
-- kind: conda
-  name: cuda-nvprof
-  version: 12.4.127
+  version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvprof-12.4.127-0.tar.bz2
-  sha256: b1ab077d9f77cab9efdcbff1da6c78da0267d526e832c64ac611bd8c8095f70d
-  md5: 789785beacc557c880f20b68b759a06b
-  size: 1686518
-  timestamp: 1710546076324
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvprof-11.6.124-0.tar.bz2
+  md5: aaec074c097d8e49ef243da53860e4f4
+  arch: x86_64
+  platform: win
+  size: 1615124
+  timestamp: 1657824255489
+- kind: conda
+  name: cuda-nvprof
+  version: 11.6.124
+  build: h7c7a4e2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvprof-11.6.124-h7c7a4e2_0.tar.bz2
+  md5: 944ff3227320c0de6e12d10f8a760de9
+  arch: x86_64
+  platform: linux
+  size: 4548001
+  timestamp: 1646799606445
 - kind: conda
   name: cuda-nvprune
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvprune-11.6.124-0.tar.bz2
-  sha256: 407e6a24ea0e0b46305adf3ef8bba3d5e0582c0ed46085674f3114854e27ea52
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvprune-11.6.124-0.tar.bz2
   md5: 794ee3f4f2c9021a4096b608cb64de2d
+  arch: x86_64
+  platform: win
   size: 155124
   timestamp: 1656527711217
 - kind: conda
@@ -1043,9 +1104,10 @@ packages:
   version: 11.6.124
   build: he22ec0a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprune-11.6.124-he22ec0a_0.tar.bz2
-  sha256: de0df40712ea69f32e0ba999923fd97262e805be6948d0f8fca2ead2d9d6f9cd
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvprune-11.6.124-he22ec0a_0.tar.bz2
   md5: 6e26d5a4e36ef88e6b5db2b4e6ffda70
+  arch: x86_64
+  platform: linux
   size: 66461
   timestamp: 1646796467738
 - kind: conda
@@ -1053,9 +1115,10 @@ packages:
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-11.6.124-0.tar.bz2
-  sha256: 2da898e5de255f507cf706cd9336840d38a30f3a52e05c1049228b17841a17f5
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvrtc-11.6.124-0.tar.bz2
   md5: 608076e88e5b2e57aa34a7f53201439f
+  arch: x86_64
+  platform: win
   size: 74878113
   timestamp: 1657033857169
 - kind: conda
@@ -1063,9 +1126,10 @@ packages:
   version: 11.6.124
   build: h020bade_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.6.124-h020bade_0.tar.bz2
-  sha256: 0615731e56b85baf89c442fa1709281788ae5f87b6b4b7f15405eb0978d24ec1
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvrtc-11.6.124-h020bade_0.tar.bz2
   md5: ea24ed9c8891eaf179529ca7848c5f88
+  arch: x86_64
+  platform: linux
   size: 17963406
   timestamp: 1646799392929
 - kind: conda
@@ -1073,11 +1137,12 @@ packages:
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-dev-11.6.124-0.tar.bz2
-  sha256: 13f1bc7b20d1b5b2082c41ac7d5cb90a092e885b383195e98bdcb5c9f73ee150
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvrtc-dev-11.6.124-0.tar.bz2
   md5: e01e07ea81dd15646052677add566f9b
   depends:
   - cuda-nvrtc >=11.6.124
+  arch: x86_64
+  platform: win
   size: 14963244
   timestamp: 1657033945716
 - kind: conda
@@ -1085,11 +1150,12 @@ packages:
   version: 11.6.124
   build: h249d397_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-dev-11.6.124-h249d397_0.tar.bz2
-  sha256: 70d0b59a7f3a882821a03298153120cf9fecb21756ebe41637e2b4d976bec539
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvrtc-dev-11.6.124-h249d397_0.tar.bz2
   md5: 650c3307c916c6442f7d39ffd243f1e7
   depends:
   - cuda-nvrtc >=11.6.124
+  arch: x86_64
+  platform: linux
   size: 17619671
   timestamp: 1646799404215
 - kind: conda
@@ -1097,9 +1163,10 @@ packages:
   version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvtx-11.6.124-0.tar.bz2
-  sha256: 3809360856d019d4279809ba52297060caf8c6f7094d0024d0620558f2785280
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvtx-11.6.124-0.tar.bz2
   md5: 2748bd39f79839cefe0f87dd83758d36
+  arch: x86_64
+  platform: win
   size: 43948
   timestamp: 1656615267248
 - kind: conda
@@ -1107,47 +1174,51 @@ packages:
   version: 11.6.124
   build: h0630a44_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.6.124-h0630a44_0.tar.bz2
-  sha256: 94bd25354cc82150800cdcda21606453019c0385b5657a3bc2788fe64092d510
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvtx-11.6.124-h0630a44_0.tar.bz2
   md5: ca92d5a3fe901d9ff81500aeb823ba49
+  arch: x86_64
+  platform: linux
   size: 59449
   timestamp: 1646799363177
 - kind: conda
   name: cuda-nvvp
-  version: 12.4.127
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvp-12.4.127-0.tar.bz2
-  sha256: dad5b6a981d34ea7886928e62ee860d82274d996c824ac9ce0e0682bfc138da0
-  md5: fe0f1f926bd04b7468df9d6c991d7b77
-  depends:
-  - cuda-nvdisasm
-  - cuda-nvprof
-  size: 120069229
-  timestamp: 1710550059475
-- kind: conda
-  name: cuda-nvvp
-  version: 12.4.127
+  version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvvp-12.4.127-0.tar.bz2
-  sha256: 4e7453cc3cacc562be617ede11f439faf8aafa25bcef83d8c59bff0c6e441fd5
-  md5: 71c90ca533a9a0e7ac6635d44f7ab8b1
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-nvvp-11.6.124-0.tar.bz2
+  md5: 1d986544cca7679df69611d6e997761d
   depends:
   - cuda-nvdisasm
   - cuda-nvprof
-  size: 119132361
-  timestamp: 1710547781188
+  arch: x86_64
+  platform: win
+  size: 119114545
+  timestamp: 1656528888250
+- kind: conda
+  name: cuda-nvvp
+  version: 11.6.124
+  build: h38ac01c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-nvvp-11.6.124-h38ac01c_0.tar.bz2
+  md5: 41d7fe9b72703a9671f3a21f3bbb7fc7
+  depends:
+  - cuda-nvdisasm
+  - cuda-nvprof
+  arch: x86_64
+  platform: linux
+  size: 119876095
+  timestamp: 1646795621665
 - kind: conda
   name: cuda-runtime
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.6.2-0.tar.bz2
-  sha256: b8f8f5958929f23a603bcbfe2a5a693e0ff93e47ef60187aef32e282ffb0de2d
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-runtime-11.6.2-0.tar.bz2
   md5: f5f915d12e7fdcb91c6ee5f5b7b39e2a
   depends:
   - cuda-libraries >=11.6.2
+  arch: x86_64
+  platform: linux
   size: 1429
   timestamp: 1656529432372
 - kind: conda
@@ -1155,11 +1226,12 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-runtime-11.6.2-0.tar.bz2
-  sha256: 90ee5cac80a67f7974601596b7e8855bfde6feecdc7f57b4299aade896106638
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-runtime-11.6.2-0.tar.bz2
   md5: d67290294337ae55071dde31c03882c3
   depends:
   - cuda-libraries >=11.6.2
+  arch: x86_64
+  platform: win
   size: 1298
   timestamp: 1657842507764
 - kind: conda
@@ -1167,38 +1239,40 @@ packages:
   version: 11.6.101
   build: h8efea70_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-samples-11.6.101-h8efea70_0.tar.bz2
-  sha256: 44965e8259962f864403db17c8d6370fc587770a02efafa1ed4a562fb1416652
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-samples-11.6.101-h8efea70_0.tar.bz2
   md5: 178b1f759964c67d2e6906ac77b02e49
+  arch: x86_64
+  platform: linux
   size: 5294
   timestamp: 1636576605917
 - kind: conda
   name: cuda-sanitizer-api
-  version: 12.4.127
-  build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
-  sha256: 479ef4c2877f59d11b4125b7e4147d1aa226906975544904022076491bf20b9f
-  md5: 3d8b2d25db78ccdbe63cae75f8056a8d
-  size: 17962299
-  timestamp: 1710553494409
-- kind: conda
-  name: cuda-sanitizer-api
-  version: 12.4.127
+  version: 11.6.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
-  sha256: 95844dc0ca7c7f6d646ce42713348f409f2632563348be6204c0800ce77c0109
-  md5: e006f8eadbf564b769f11fc833ad07a5
-  size: 13808433
-  timestamp: 1710544035417
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-sanitizer-api-11.6.124-0.tar.bz2
+  md5: 9eeb49a5174697ec02f5cb96f8c0d0bb
+  arch: x86_64
+  platform: win
+  size: 12928656
+  timestamp: 1656450111255
+- kind: conda
+  name: cuda-sanitizer-api
+  version: 11.6.124
+  build: h3d04c53_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-sanitizer-api-11.6.124-h3d04c53_0.tar.bz2
+  md5: eaf24e41eae856066d04a1b20ce0d0bb
+  arch: x86_64
+  platform: linux
+  size: 17216021
+  timestamp: 1646805867757
 - kind: conda
   name: cuda-toolkit
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-toolkit-11.6.2-0.tar.bz2
-  sha256: 498c7fb8fd4ab4a834b6d76469d2ad57a3d109f4b8adf7949c9771f21df1eb6d
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-toolkit-11.6.2-0.tar.bz2
   md5: ecb8389ea291cc57c80d22625b2307dc
   depends:
   - cuda-compiler >=11.6.2
@@ -1207,6 +1281,8 @@ packages:
   - cuda-nvml-dev >=11.6.55
   - cuda-samples >=11.6.101
   - cuda-tools >=11.6.2
+  arch: x86_64
+  platform: linux
   size: 1471
   timestamp: 1656529467544
 - kind: conda
@@ -1214,8 +1290,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-toolkit-11.6.2-0.tar.bz2
-  sha256: fa6579510cb7b79fca240163665e3feab4e32ecea0080e97800b2834a0bfa4cd
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-toolkit-11.6.2-0.tar.bz2
   md5: a159048e84f6debd212947ff6a34b900
   depends:
   - cuda-compiler >=11.6.2
@@ -1223,6 +1298,8 @@ packages:
   - cuda-libraries-dev >=11.6.2
   - cuda-nvml-dev >=11.6.55
   - cuda-tools >=11.6.2
+  arch: x86_64
+  platform: win
   size: 1334
   timestamp: 1657842540971
 - kind: conda
@@ -1230,13 +1307,14 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-tools-11.6.2-0.tar.bz2
-  sha256: 54cafb8e852a9035ff90ed372f9afff16e96368d8bdb497967fbe4feb91ca5b7
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-tools-11.6.2-0.tar.bz2
   md5: ddcd6d63faa8f867ab9862cef7618a91
   depends:
   - cuda-command-line-tools >=11.6.2
   - cuda-visual-tools >=11.6.2
   - gds-tools >=1.2.1.4
+  arch: x86_64
+  platform: linux
   size: 1452
   timestamp: 1656529455847
 - kind: conda
@@ -1244,12 +1322,13 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-tools-11.6.2-0.tar.bz2
-  sha256: b89b71d5635db763b31db54b224f26108e36c541b77da2934b2ff03e4c9d763d
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-tools-11.6.2-0.tar.bz2
   md5: c4a069a22142209f6445bb6429d8669d
   depends:
   - cuda-command-line-tools >=11.6.2
   - cuda-visual-tools >=11.6.2
+  arch: x86_64
+  platform: win
   size: 1314
   timestamp: 1657842529942
 - kind: conda
@@ -1257,8 +1336,7 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-visual-tools-11.6.2-0.tar.bz2
-  sha256: 24ab2459710a89a48cf0f1cd470bb154fea4577e5a2c97f553e98b39912db0fa
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/cuda-visual-tools-11.6.2-0.tar.bz2
   md5: d180f95176c7efb6f9bd11a3fbf88218
   depends:
   - cuda-libraries-dev >=11.6.2
@@ -1266,6 +1344,8 @@ packages:
   - cuda-nsight-compute >=11.6.2
   - cuda-nvml-dev >=11.6.55
   - cuda-nvvp >=11.6.124
+  arch: x86_64
+  platform: linux
   size: 1484
   timestamp: 1656529444052
 - kind: conda
@@ -1273,39 +1353,179 @@ packages:
   version: 11.6.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/cuda-visual-tools-11.6.2-0.tar.bz2
-  sha256: 4389f541556a347963e92117a049905a537a1cd684761baf81fe27090c04ac85
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/cuda-visual-tools-11.6.2-0.tar.bz2
   md5: a804f7945bd167de997b57a0d86ea7e6
   depends:
   - cuda-libraries-dev >=11.6.2
   - cuda-nsight-compute >=11.6.2
   - cuda-nvml-dev >=11.6.55
   - cuda-nvvp >=11.6.124
+  arch: x86_64
+  platform: win
   size: 1341
   timestamp: 1657842518654
 - kind: conda
-  name: ffmpeg
-  version: '4.3'
-  build: hf484d3e_0
+  name: expat
+  version: 2.6.3
+  build: h5888daf_0
   subdir: linux-64
-  url: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
-  sha256: 60b3e36cb36b706f5850f155bd9d3f33194a522b5ef20be46cb37dbc987a6741
-  md5: 0b0bf7c3d7e146ef91de5310bbf7a230
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+  sha256: 65bd479c75ce876f26600cb230d6ebc474086e31fa384af9b4282b36842ed7e2
+  md5: 6595440079bed734b113de44ffd3cd0a
   depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - freetype >=2.10.2,<3.0a0
-  - gmp >=6.1.2
-  - gnutls >=3.6.5,<3.7.0a0
-  - lame >=3.100,<3.101.0a0
-  - libgcc-ng >=7.3.0
-  - libiconv
-  - libstdcxx-ng >=7.3.0
-  - openh264 >=2.1.0,<2.2.0a0
-  - zlib >=1.2.11,<1.3.0a0
-  license: LGPL
+  - __glibc >=2.17,<3.0.a0
+  - libexpat 2.6.3 h5888daf_0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 10426878
-  timestamp: 1596130242227
+  size: 137891
+  timestamp: 1725568750673
+- kind: conda
+  name: ffmpeg
+  version: 5.1.2
+  build: gpl_h8dda1f0_106
+  build_number: 106
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-5.1.2-gpl_h8dda1f0_106.conda
+  sha256: be22acd41af31933f835c86998052d7a7073f9c8b267f01f5f3d8c501a2ce21f
+  md5: 6845420373a9e260942bfbc5c786a4bb
+  depends:
+  - aom >=3.5.0,<3.6.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - fontconfig >=2.14.1,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.2.1,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libgcc-ng >=12
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libva >=2.17.0,<3.0a0
+  - libvpx >=1.11.0,<1.12.0a0
+  - libxml2 >=2.10.3,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openh264 >=2.3.1,<2.3.2.0a0
+  - svt-av1 >=1.4.1,<1.4.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 9621299
+  timestamp: 1674566990384
+- kind: conda
+  name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  build: hab24e00_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 397370
+  timestamp: 1566932522327
+- kind: conda
+  name: font-ttf-inconsolata
+  version: '3.000'
+  build: h77eed37_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 96530
+  timestamp: 1620479909603
+- kind: conda
+  name: font-ttf-source-code-pro
+  version: '2.038'
+  build: h77eed37_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 700814
+  timestamp: 1620479612257
+- kind: conda
+  name: font-ttf-ubuntu
+  version: '0.83'
+  build: h77eed37_2
+  build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
+  md5: cbbe59391138ea5ad3658c76912e147f
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  purls: []
+  size: 1622566
+  timestamp: 1714483134319
+- kind: conda
+  name: fontconfig
+  version: 2.14.2
+  build: h14ed4e7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+  sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
+  md5: 0f69b688f52ff6da70bccb7ff7001d1d
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 272010
+  timestamp: 1674828850194
+- kind: conda
+  name: fonts-conda-ecosystem
+  version: '1'
+  build: '0'
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3667
+  timestamp: 1566974674465
+- kind: conda
+  name: fonts-conda-forge
+  version: '1'
+  build: '0'
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-inconsolata
+  - font-ttf-source-code-pro
+  - font-ttf-ubuntu
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4102
+  timestamp: 1566932280397
 - kind: conda
   name: freetype
   version: 2.12.1
@@ -1343,42 +1563,57 @@ packages:
   size: 510306
   timestamp: 1694616398888
 - kind: conda
-  name: fvcore
-  version: 0.1.5.post20221221
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/fvcore-0.1.5.post20221221-pyhd8ed1ab_0.conda
-  sha256: 642838ed0ef162ff3ae5817971b5cb5d452c73d655bfa384adecb8f268619e01
-  md5: 0a0797787d4c8d9f7b767da76774efad
-  depends:
-  - numpy
-  - pillow
-  - portalocker
-  - python >=3.6
-  - pyyaml >=5.1
-  - tabulate
-  - termcolor >=1.1
-  - tqdm
-  - yacs >=0.1.6
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/fvcore?source=hash-mapping
-  size: 60175
-  timestamp: 1671623775701
-- kind: conda
   name: gds-tools
-  version: 1.9.1.3
+  version: 1.2.1.4
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/gds-tools-1.9.1.3-0.tar.bz2
-  sha256: 786e251ef09733a120829baa842ba9ba60d1598f10475a2962c5a7597426ae55
-  md5: c434e7cafa6663ecf3953f00a099ac23
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/gds-tools-1.2.1.4-0.tar.bz2
+  md5: 31f5642775632c5d75f6f412733b1b71
   depends:
-  - libcufile >=1.9.1.3
-  size: 42707168
-  timestamp: 1710365911168
+  - libcufile >=1.2.1.4
+  arch: x86_64
+  platform: linux
+  size: 41644045
+  timestamp: 1656528515812
+- kind: conda
+  name: gettext
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-he02047a_3.conda
+  sha256: c3d9a453f523acbf2b3e1c82a42edfc7c7111b4686a2180ab48cb9b51a274218
+  md5: c7f243bbaea97cd6ea1edd693270100e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gettext-tools 0.22.5 he02047a_3
+  - libasprintf 0.22.5 he8f35ee_3
+  - libasprintf-devel 0.22.5 he8f35ee_3
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 he02047a_3
+  - libgettextpo-devel 0.22.5 he02047a_3
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  purls: []
+  size: 479452
+  timestamp: 1723626088190
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-he02047a_3.conda
+  sha256: 0fd003953ce1ce9f4569458aab9ffaa397e3be2bc069250e2f05fd93b0ad2976
+  md5: fcd2016d1d299f654f81021e27496818
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 2750908
+  timestamp: 1723626056740
 - kind: conda
   name: gmp
   version: 6.3.0
@@ -1397,23 +1632,24 @@ packages:
   timestamp: 1718980856608
 - kind: conda
   name: gnutls
-  version: 3.6.13
-  build: h85f3911_1
-  build_number: 1
+  version: 3.7.9
+  build: hb077bed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
-  sha256: 6c9307f0fedce2c4d060bba9ac888b300bc0912effab423d67b8e1b661a93305
-  md5: 7d1b6fff16c1431d96cb4934938799fd
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+  sha256: 52d824a5d2b8a5566cd469cae6ad6920469b5a15b3e0ddc609dd29151be71be2
+  md5: 33eded89024f21659b1975886a4acf70
   depends:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  - nettle >=3.4.1
-  - nettle >=3.6,<3.7.0a0
+  - libgcc-ng >=12
+  - libidn2 >=2,<3.0a0
+  - libstdcxx-ng >=12
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
   license: LGPL-2.1-or-later
   license_family: LGPL
   purls: []
-  size: 2096527
-  timestamp: 1605742597225
+  size: 1974935
+  timestamp: 1701111180127
 - kind: conda
   name: h2
   version: 4.1.0
@@ -1469,20 +1705,21 @@ packages:
   timestamp: 1619110249723
 - kind: conda
   name: icu
-  version: '73.2'
-  build: h59595ed_0
+  version: '75.1'
+  build: he02047a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  md5: cc47e1facc155f91abd89b11e48e72ff
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 12089150
-  timestamp: 1692900650789
+  size: 12129203
+  timestamp: 1720853576813
 - kind: conda
   name: idna
   version: '3.8'
@@ -1663,6 +1900,40 @@ packages:
   size: 194365
   timestamp: 1657977692274
 - kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: he8f35ee_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-he8f35ee_3.conda
+  sha256: 2da5c735811cbf38c7f7844ab457ff8b25046bbf5fe5ebd5dc1c2fafdf4fbe1c
+  md5: 4fab9799da9571266d05ca5503330655
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 42817
+  timestamp: 1723626012203
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: he8f35ee_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-he8f35ee_3.conda
+  sha256: ccc7967e298ddf3124c8ad9741c7180dc6f778ae4135ec87978214f7b3c64dc2
+  md5: 1091193789bb830127ed067a9e01ac57
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libasprintf 0.22.5 he8f35ee_3
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 34172
+  timestamp: 1723626026096
+- kind: conda
   name: libblas
   version: 3.9.0
   build: 1_h8933c1f_netlib
@@ -1746,246 +2017,268 @@ packages:
   timestamp: 1618013041863
 - kind: conda
   name: libcublas
-  version: 12.4.5.8
+  version: 11.9.2.110
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-12.4.5.8-0.tar.bz2
-  sha256: 341dcb4c3bdc2a105d9352e8cddb5011dbf5c7bfedb5930fb5bae2dedb6d5c02
-  md5: 1ca600f8d1329496d8c21c904be007dc
-  size: 324199551
-  timestamp: 1711452729415
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcublas-11.9.2.110-0.tar.bz2
+  md5: 2224e2064a8048127f42c31c856116a4
+  arch: x86_64
+  platform: win
+  size: 24446
+  timestamp: 1656986453141
 - kind: conda
   name: libcublas
-  version: 12.4.5.8
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcublas-12.4.5.8-0.tar.bz2
-  sha256: 45536c2176e79a02d52d9347a6888cd8a44a590f7fe02319106d889fd7341447
-  md5: f0c09cc7daea6c4f88447948e582b778
-  size: 35171
-  timestamp: 1711455085444
+  version: 11.9.2.110
+  build: h5e84587_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcublas-11.9.2.110-h5e84587_0.tar.bz2
+  md5: 7cbe5a54d0ce38c67f58e855c2ee3c28
+  arch: x86_64
+  platform: linux
+  size: 315425673
+  timestamp: 1647497441697
 - kind: conda
   name: libcublas-dev
-  version: 12.4.5.8
+  version: 11.9.2.110
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-dev-12.4.5.8-0.tar.bz2
-  sha256: 4d5de328af7e1a2ca0bb099fb67c3cf6535a1710a67857951203c375d588617f
-  md5: 3f4a986f221f132d77d5b421fda721c0
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcublas-dev-11.9.2.110-0.tar.bz2
+  md5: 22bd2c78fc31e8a9181112bf53d1fad9
   depends:
-  - libcublas >=12.4.5.8
-  size: 76659
-  timestamp: 1711452843192
+  - libcublas >=11.9.2.110
+  arch: x86_64
+  platform: win
+  size: 311278235
+  timestamp: 1656986507729
 - kind: conda
   name: libcublas-dev
-  version: 12.4.5.8
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcublas-dev-12.4.5.8-0.tar.bz2
-  sha256: 32747ea55f66df4d059275d0a137f4436ee2deb34d733992b7ca9a6c783cb98c
-  md5: 4cef35b1d916d30c81b0cf05e7b36327
+  version: 11.9.2.110
+  build: h5c901ab_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcublas-dev-11.9.2.110-h5c901ab_0.tar.bz2
+  md5: 3c354acbeb11d16dea10127c1ca58e2b
   depends:
-  - libcublas >=12.4.5.8
-  size: 361381245
-  timestamp: 1711455367600
+  - libcublas >=11.9.2.110
+  arch: x86_64
+  platform: linux
+  size: 325997564
+  timestamp: 1647497623639
 - kind: conda
   name: libcufft
-  version: 11.2.1.3
+  version: 10.7.2.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-11.2.1.3-0.tar.bz2
-  sha256: ddca1aedf91e825e688e4d982a25c569fe215d69814f63db350c16d693f3eac8
-  md5: 19d9ed3642b9be9ca2565f52ed5ce787
-  size: 199783504
-  timestamp: 1710543633676
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcufft-10.7.2.124-0.tar.bz2
+  md5: 009a4fc233a736d55bd52793a25eb432
+  arch: x86_64
+  platform: win
+  size: 5646
+  timestamp: 1657640220743
 - kind: conda
   name: libcufft
-  version: 11.2.1.3
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcufft-11.2.1.3-0.tar.bz2
-  sha256: b349231aa80555fa576d06bac443b57fac2cd81787c20e661e2f0e9d57bc2ae5
-  md5: dc06b183f8f738201bc2596f83998d83
-  size: 6086
-  timestamp: 1710546148766
-- kind: conda
-  name: libcufft-dev
-  version: 11.2.1.3
-  build: '0'
+  version: 10.7.2.124
+  build: h4fbf590_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-dev-11.2.1.3-0.tar.bz2
-  sha256: 2dfb413fb3375561523720c41efcaba70508cd5327c56d34fcfd55dfa6081972
-  md5: 8f30ed45d91f27edab17e53f74feae99
-  depends:
-  - libcufft >=11.2.1.3
-  size: 14754
-  timestamp: 1710543692819
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufft-10.7.2.124-h4fbf590_0.tar.bz2
+  md5: dc69f1daa40372e9b869064ab926ee26
+  arch: x86_64
+  platform: linux
+  size: 98119711
+  timestamp: 1646799908932
 - kind: conda
   name: libcufft-dev
-  version: 11.2.1.3
+  version: 10.7.2.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcufft-dev-11.2.1.3-0.tar.bz2
-  sha256: c1c0f3f5d936bc2ced7990f653d688e7c0c25bad24510c764124172918e74981
-  md5: cf314f36b8ece1e6930ac998b8fa22aa
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcufft-dev-10.7.2.124-0.tar.bz2
+  md5: 9e06561012807d91bcee1582f945208b
   depends:
-  - libcufft >=11.2.1.3
-  size: 198753382
-  timestamp: 1710546296741
+  - libcufft >=10.7.2.124
+  arch: x86_64
+  platform: win
+  size: 262240633
+  timestamp: 1657640274454
+- kind: conda
+  name: libcufft-dev
+  version: 10.7.2.124
+  build: h98a8f43_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufft-dev-10.7.2.124-h98a8f43_0.tar.bz2
+  md5: 291611d7a15ca3253452a16070c63b20
+  depends:
+  - libcufft >=10.7.2.124
+  arch: x86_64
+  platform: linux
+  size: 206839178
+  timestamp: 1646799957173
 - kind: conda
   name: libcufile
-  version: 1.9.1.3
+  version: 1.2.1.4
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.9.1.3-0.tar.bz2
-  sha256: e820395b70a93832a3a8625c637d89c512e18b2158e43f982a74cfe05e168b60
-  md5: 9cfc0beef98713d3be47f934251b5154
-  size: 1056458
-  timestamp: 1710365909934
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufile-1.2.1.4-0.tar.bz2
+  md5: a6b9063d5457aefcdfa90c2188f098a9
+  arch: x86_64
+  platform: linux
+  size: 550454
+  timestamp: 1656528513451
 - kind: conda
   name: libcufile-dev
-  version: 1.9.1.3
+  version: 1.2.1.4
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.9.1.3-0.tar.bz2
-  sha256: c01420a94058ba58aa19d8dc07e99243ded68b424fd82e73ad0da12ef5a4c037
-  md5: aed936244622103d2ca59a308ff0f421
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcufile-dev-1.2.1.4-0.tar.bz2
+  md5: 66a6de542b35c827ce30437e04cd7895
   depends:
-  - libcufile >=1.9.1.3
-  size: 14955
-  timestamp: 1710365923835
+  - libcufile >=1.2.1.4
+  arch: x86_64
+  platform: linux
+  size: 12758474
+  timestamp: 1656528532471
 - kind: conda
   name: libcurand
-  version: 10.3.5.147
+  version: 10.2.9.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.5.147-0.tar.bz2
-  sha256: cb15f89cfb48e735d93b0c96c81b36dd05c9b23f0d0228677016d5042bb6a928
-  md5: e9406bdc4209f8cd5fdb40c8df41d3d9
-  size: 54279240
-  timestamp: 1710543564823
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcurand-10.2.9.124-0.tar.bz2
+  md5: c082842b05d46ed75c8a58d058c07d24
+  arch: x86_64
+  platform: win
+  size: 3117
+  timestamp: 1656991584196
 - kind: conda
   name: libcurand
-  version: 10.3.5.147
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcurand-10.3.5.147-0.tar.bz2
-  sha256: 039ad35b8cb50bdfbacbad67cbc8496aaa1f9afabf9d2945c77d6bcf5d6d1c0f
-  md5: a28f5f60348a2f498314d47f9c677441
-  size: 3622
-  timestamp: 1710545967557
+  version: 10.2.9.124
+  build: h37c27f7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcurand-10.2.9.124-h37c27f7_0.tar.bz2
+  md5: 526af01730b045668c76c424c622e445
+  arch: x86_64
+  platform: linux
+  size: 52761876
+  timestamp: 1646799204308
 - kind: conda
   name: libcurand-dev
-  version: 10.3.5.147
+  version: 10.2.9.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.3.5.147-0.tar.bz2
-  sha256: 8ab901ab07a45f37cf4a77f2fcc7ae92ec65de386afe9fe512452685e5a0293f
-  md5: 3f0b52f4076c3d8c857664629319f1cf
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcurand-dev-10.2.9.124-0.tar.bz2
+  md5: f02c832459f2c8ea722262bba2650e04
   depends:
-  - libcurand >=10.3.5.147
-  size: 460690
-  timestamp: 1710543587166
+  - libcurand >=10.2.9.124
+  arch: x86_64
+  platform: win
+  size: 51685477
+  timestamp: 1656991635772
 - kind: conda
   name: libcurand-dev
-  version: 10.3.5.147
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcurand-dev-10.3.5.147-0.tar.bz2
-  sha256: be06a8bcadcc30117a0a7d34a9f88f19fd70e6b72addc56069b4f12795e3dd44
-  md5: 5e7299fb7982b3add1ea8580b56e58a5
+  version: 10.2.9.124
+  build: h54cfa4b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcurand-dev-10.2.9.124-h54cfa4b_0.tar.bz2
+  md5: 8ca9f620dd6a9366d36487b0972de05c
   depends:
-  - libcurand >=10.3.5.147
-  size: 52136536
-  timestamp: 1710546052359
+  - libcurand >=10.2.9.124
+  arch: x86_64
+  platform: linux
+  size: 53272765
+  timestamp: 1646799228942
 - kind: conda
   name: libcusolver
-  version: 11.6.1.9
+  version: 11.3.4.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.6.1.9-0.tar.bz2
-  sha256: 40ca27c4434bd6c5b3731e3fa359808fd31d88a5b6427e7119e19f47c43d5d94
-  md5: 5f4393c1f6f28d1eaaef31fdd5005995
-  size: 119531746
-  timestamp: 1711623954011
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusolver-11.3.4.124-0.tar.bz2
+  md5: 82f72fe6442f8b5bd333a25c6baa9e0f
+  arch: x86_64
+  platform: win
+  size: 30033
+  timestamp: 1657641818894
 - kind: conda
   name: libcusolver
-  version: 11.6.1.9
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusolver-11.6.1.9-0.tar.bz2
-  sha256: 8d9d2991b27e6dd66bf354170c82c0bc47d72887608abfb28bc355255ebac647
-  md5: bbcfa30b8dc8886329358c1559c7a794
-  size: 29805
-  timestamp: 1711630059586
+  version: 11.3.4.124
+  build: h33c3c4e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusolver-11.3.4.124-h33c3c4e_0.tar.bz2
+  md5: 430b7a04b3bfea972d479adc293c4885
+  arch: x86_64
+  platform: linux
+  size: 91264656
+  timestamp: 1646852362016
 - kind: conda
   name: libcusolver-dev
-  version: 11.6.1.9
+  version: 11.3.4.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-dev-11.6.1.9-0.tar.bz2
-  sha256: 10c13d369a6fa6a9fd5f635f0e3feab8468342809fd32866e5aa5fe64239359d
-  md5: 925d1704fc89a116c60b6ff058916133
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusolver-dev-11.3.4.124-0.tar.bz2
+  md5: a7ba7ae0894658ec77eb3b5d02f6b5a6
   depends:
-  - libcusolver >=11.6.1.9
-  size: 50331
-  timestamp: 1711623993744
+  - libcusolver >=11.3.4.124
+  arch: x86_64
+  platform: win
+  size: 89723837
+  timestamp: 1657641875016
 - kind: conda
   name: libcusolver-dev
-  version: 11.6.1.9
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusolver-dev-11.6.1.9-0.tar.bz2
-  sha256: 3d2b4fa24a66e034c0d4148329a0885941a12292459a791c0fd3cde8f839e088
-  md5: d2ea6c1a8abe5a436c9f59a35e45a69f
+  version: 11.3.4.124
+  build: h203c794_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusolver-dev-11.3.4.124-h203c794_0.tar.bz2
+  md5: 0792df27ef97d3f2548e5a38d45dbda8
   depends:
-  - libcusolver >=11.6.1.9
-  size: 116774002
-  timestamp: 1711630142669
+  - libcusolver >=11.3.4.124
+  arch: x86_64
+  platform: linux
+  size: 60418679
+  timestamp: 1646852456432
 - kind: conda
   name: libcusparse
-  version: 12.3.1.170
+  version: 11.7.2.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-12.3.1.170-0.tar.bz2
-  sha256: 8bc0bb3636feb2e7a20cd47907d7fc6d7a28aea54c4731496f11d2a259b574f2
-  md5: e5d6c740f6a6a6fb28f71cbabef7a613
-  size: 188320273
-  timestamp: 1710544351539
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusparse-11.7.2.124-0.tar.bz2
+  md5: 9b9a70921e8db53ce9e5a41f344947f6
+  arch: x86_64
+  platform: win
+  size: 13773
+  timestamp: 1657641076678
 - kind: conda
   name: libcusparse
-  version: 12.3.1.170
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusparse-12.3.1.170-0.tar.bz2
-  sha256: f1f893ea386bd60faefb6f00c381c3ff5d37e1ade5cc76ebcd7ab237a7501ae7
-  md5: 3d3de5146dabaff5a217710fa052a159
-  size: 13077
-  timestamp: 1710546804883
-- kind: conda
-  name: libcusparse-dev
-  version: 12.3.1.170
-  build: '0'
+  version: 11.7.2.124
+  build: h7538f96_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-dev-12.3.1.170-0.tar.bz2
-  sha256: 2185a04d01af549a7930199d25fb91995c6c35ec30469ad66f1ceb508f1969d3
-  md5: 3d3f81963e5a36e2b66fa2e5b31cb304
-  depends:
-  - libcusparse >=12.3.1.170
-  size: 186871715
-  timestamp: 1710544411513
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusparse-11.7.2.124-h7538f96_0.tar.bz2
+  md5: c7b01e6aa817f7749c7c7dfc43acb51f
+  arch: x86_64
+  platform: linux
+  size: 168749053
+  timestamp: 1646799420643
 - kind: conda
   name: libcusparse-dev
-  version: 12.3.1.170
+  version: 11.7.2.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libcusparse-dev-12.3.1.170-0.tar.bz2
-  sha256: 5b85df69a99e1990254bbbcc5ce1c4ef24820b648bf1009474de367a06248746
-  md5: 6591783b48eac8d587cca3ced3adfe7f
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libcusparse-dev-11.7.2.124-0.tar.bz2
+  md5: 55dc12f61994ab6e408960a8884a0f18
   depends:
-  - libcusparse >=12.3.1.170
-  size: 184496918
-  timestamp: 1710546892759
+  - libcusparse >=11.7.2.124
+  arch: x86_64
+  platform: win
+  size: 168770995
+  timestamp: 1657641129310
+- kind: conda
+  name: libcusparse-dev
+  version: 11.7.2.124
+  build: hbbe9722_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libcusparse-dev-11.7.2.124-hbbe9722_0.tar.bz2
+  md5: 40689cc4b156089c374293f8ce41ff8b
+  depends:
+  - libcusparse >=11.7.2.124
+  arch: x86_64
+  platform: linux
+  size: 344890455
+  timestamp: 1646799511395
 - kind: conda
   name: libdeflate
   version: '1.17'
@@ -2018,6 +2311,41 @@ packages:
   purls: []
   size: 151946
   timestamp: 1673786168055
+- kind: conda
+  name: libdrm
+  version: 2.4.123
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.123-hb9d3cd8_0.conda
+  sha256: 5f274243fc7480b721a4ed6623c72d07b86a508a1363a85f0f16451ab655ace8
+  md5: ee605e794bdc14e2b7f84c4faa0d8c2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=13
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 303108
+  timestamp: 1724719521496
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+  sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
+  md5: 59f4c43bb1b5ef1c71946ff2cbf59524
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 73616
+  timestamp: 1725568742634
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -2087,6 +2415,41 @@ packages:
   purls: []
   size: 52170
   timestamp: 1724801842101
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-he02047a_3.conda
+  sha256: 7f2d1f4d69973e2c3c3d2b6420d5eb989982baba97d63ab2d7a2b25a92d886b4
+  md5: efab66b82ec976930b96d62a976de8e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 170646
+  timestamp: 1723626019265
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: he02047a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-he02047a_3.conda
+  sha256: 0a66cdd46d1cd5201061252535cd91905b3222328a9294c1a5bcd32e85531545
+  md5: 9aba7960731e6b4547b3a52f812ed801
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 he02047a_3
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 36790
+  timestamp: 1723626032786
 - kind: conda
   name: libgfortran
   version: 14.1.0
@@ -2211,6 +2574,22 @@ packages:
   size: 705775
   timestamp: 1702682170569
 - kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+  sha256: 253f9be445c58bf07b39d8f67ac08bccc5010c75a8c2070cddfb6c20e1ca4f4f
+  md5: 2b7b0d827c6447cc1d85dc06d5b5de46
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  purls: []
+  size: 126515
+  timestamp: 1706368269716
+- kind: conda
   name: liblapack
   version: 3.9.0
   build: 21_linux64_mkl
@@ -2275,48 +2654,52 @@ packages:
   timestamp: 1705979627914
 - kind: conda
   name: libnpp
-  version: 12.2.5.30
+  version: 11.6.3.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-12.2.5.30-0.tar.bz2
-  sha256: fbad0c1fb5737312c780d65816512d4e84b87c1a782aab90d01b250305af3891
-  md5: 528dd173d5883e27ecd3cb1e25f6ec03
-  size: 149716917
-  timestamp: 1710543759259
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnpp-11.6.3.124-0.tar.bz2
+  md5: 805408037c9f95e94acf0384a0eaaf65
+  arch: x86_64
+  platform: win
+  size: 292765
+  timestamp: 1657640674009
 - kind: conda
   name: libnpp
-  version: 12.2.5.30
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnpp-12.2.5.30-0.tar.bz2
-  sha256: 0e5799c28b9d3a7486c205431785dcccde09342a03b595875550eab3908dfdb3
-  md5: ef1bbea5b348039d82d18604b2deefdf
-  size: 317786
-  timestamp: 1710548580563
-- kind: conda
-  name: libnpp-dev
-  version: 12.2.5.30
-  build: '0'
+  version: 11.6.3.124
+  build: hd2722f0_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-dev-12.2.5.30-0.tar.bz2
-  sha256: 520f440de00aadcc66e00eacf5814854685ce0d68cbcf51222e3aab0c5d5fe92
-  md5: fc0ff7966b2fc067b8ae0b101c75836f
-  depends:
-  - libnpp >=12.2.5.30
-  size: 551586
-  timestamp: 1710543810642
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnpp-11.6.3.124-hd2722f0_0.tar.bz2
+  md5: 5d7beb9f0891d6c8375a8319fabbb2b8
+  arch: x86_64
+  platform: linux
+  size: 124137356
+  timestamp: 1646799932068
 - kind: conda
   name: libnpp-dev
-  version: 12.2.5.30
+  version: 11.6.3.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnpp-dev-12.2.5.30-0.tar.bz2
-  sha256: 4bf0b9448cbeba4ed4f2b67b0ae31dcc337f77e076d8af06301dba0dd4a974f5
-  md5: af51f6595654ae6b575cb5685a1dd9f4
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnpp-dev-11.6.3.124-0.tar.bz2
+  md5: 47be53e6160bd4ed9304b80c8620fa48
   depends:
-  - libnpp >=12.2.5.30
-  size: 145964412
-  timestamp: 1710548706373
+  - libnpp >=11.6.3.124
+  arch: x86_64
+  platform: win
+  size: 120156419
+  timestamp: 1657640729112
+- kind: conda
+  name: libnpp-dev
+  version: 11.6.3.124
+  build: h3c42840_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnpp-dev-11.6.3.124-h3c42840_0.tar.bz2
+  md5: f4616850c8376b4da8bac49e8549f545
+  depends:
+  - libnpp >=11.6.3.124
+  arch: x86_64
+  platform: linux
+  size: 121220200
+  timestamp: 1646799997008
 - kind: conda
   name: libnsl
   version: 2.0.1
@@ -2334,48 +2717,83 @@ packages:
   timestamp: 1697359010159
 - kind: conda
   name: libnvjpeg
-  version: 12.3.1.117
+  version: 11.6.2.124
   build: '0'
-  subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-12.3.1.117-0.tar.bz2
-  sha256: ae7a9caa5f4b8391eccdf58475f19c34f99072678ecac071470eccd0d837482f
-  md5: a74e60028f611186ca17095d2d5074d1
-  size: 3107405
-  timestamp: 1710543206669
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnvjpeg-11.6.2.124-0.tar.bz2
+  md5: 15aaa5ceecf80112bfb76b1abb68d5b0
+  arch: x86_64
+  platform: win
+  size: 4390
+  timestamp: 1657740215601
 - kind: conda
   name: libnvjpeg
-  version: 12.3.1.117
-  build: '0'
-  subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-12.3.1.117-0.tar.bz2
-  sha256: a0d59a353c24a7b94fe5f1fb45087d1d8c905b6045e318176d40dc8847e961a8
-  md5: 3cc2be851bf0a74a00b62ba91651a3f0
-  size: 5050
-  timestamp: 1710545702272
-- kind: conda
-  name: libnvjpeg-dev
-  version: 12.3.1.117
-  build: '0'
+  version: 11.6.2.124
+  build: hd473ad6_0
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
-  sha256: e2159fb7804c1d7c75f8fc8923023de175e45e1cf3c46ea7a4add14079c21878
-  md5: c3bef7506f27273e0d4c0ff87ff84628
-  depends:
-  - libnvjpeg >=12.3.1.117
-  size: 13464
-  timestamp: 1710543208085
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnvjpeg-11.6.2.124-hd473ad6_0.tar.bz2
+  md5: fb32cd24be9763dc3adb63fb6f769660
+  arch: x86_64
+  platform: linux
+  size: 2433694
+  timestamp: 1646801893862
 - kind: conda
   name: libnvjpeg-dev
-  version: 12.3.1.117
+  version: 11.6.2.124
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
-  sha256: 89cd948aeb10758a72cc763df14a9cafc2b6bae1f87562bdfc97376dd563eb19
-  md5: 49fe5ba7019892aee92531981864066b
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/libnvjpeg-dev-11.6.2.124-0.tar.bz2
+  md5: b784d9fddacf000f75f61364c5b41069
   depends:
-  - libnvjpeg >=12.3.1.117
-  size: 2621000
-  timestamp: 1710545783617
+  - libnvjpeg >=11.6.2.124
+  arch: x86_64
+  platform: win
+  size: 1925591
+  timestamp: 1657740265200
+- kind: conda
+  name: libnvjpeg-dev
+  version: 11.6.2.124
+  build: hb5906b9_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/libnvjpeg-dev-11.6.2.124-hb5906b9_0.tar.bz2
+  md5: 4d3587b4cb9c5f6bffefdddd3142f066
+  depends:
+  - libnvjpeg >=11.6.2.124
+  arch: x86_64
+  platform: linux
+  size: 2120411
+  timestamp: 1646801895584
+- kind: conda
+  name: libopus
+  version: 1.3.1
+  build: h7f98852_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+  sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
+  md5: 15345e56d527b330e1cacbdf58676e8f
+  depends:
+  - libgcc-ng >=9.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 260658
+  timestamp: 1606823578035
+- kind: conda
+  name: libpciaccess
+  version: '0.18'
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+  sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
+  md5: 48f4330bfcd959c3cfb704d424903c82
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 28361
+  timestamp: 1707101388552
 - kind: conda
   name: libpng
   version: 1.6.43
@@ -2410,21 +2828,6 @@ packages:
   timestamp: 1708780443939
 - kind: conda
   name: libsqlite
-  version: 3.46.0
-  build: hde9e2c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
-  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
-  md5: 18aa975d2094c34aef978060ae7da7d8
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0a0
-  license: Unlicense
-  purls: []
-  size: 865346
-  timestamp: 1718050628718
-- kind: conda
-  name: libsqlite
   version: 3.46.1
   build: h2466b09_0
   subdir: win-64
@@ -2439,6 +2842,22 @@ packages:
   purls: []
   size: 876666
   timestamp: 1725354171439
+- kind: conda
+  name: libsqlite
+  version: 3.46.1
+  build: hadc24fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
+  sha256: 9851c049abafed3ee329d6c7c2033407e2fc269d33a75c071110ab52300002b0
+  md5: 36f79405ab16bf271edb55b213836dac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 865214
+  timestamp: 1725353659783
 - kind: conda
   name: libstdcxx
   version: 14.1.0
@@ -2471,6 +2890,21 @@ packages:
   purls: []
   size: 52219
   timestamp: 1724801897766
+- kind: conda
+  name: libtasn1
+  version: 4.19.0
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+  sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
+  md5: 93840744a8552e9ebf6bb1a5dffc125a
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  size: 116878
+  timestamp: 1661325701583
 - kind: conda
   name: libtiff
   version: 4.5.0
@@ -2518,6 +2952,20 @@ packages:
   size: 1156984
   timestamp: 1673818439563
 - kind: conda
+  name: libunistring
+  version: 0.9.10
+  build: h7f98852_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+  sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
+  md5: 7245a044b4a1980ed83196176b78b73a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: GPL-3.0-only OR LGPL-3.0-only
+  purls: []
+  size: 1433436
+  timestamp: 1626955018689
+- kind: conda
   name: libuuid
   version: 2.38.1
   build: h0b41bf4_0
@@ -2549,6 +2997,42 @@ packages:
   purls: []
   size: 289753
   timestamp: 1709913743184
+- kind: conda
+  name: libva
+  version: 2.18.0
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.18.0-h0b41bf4_0.conda
+  sha256: e7254d0111a403ffe707e2ad39b6ce49a2be733e751d14a7255b0cb20da2a16b
+  md5: 56e049224de34bbe0478aad422227942
+  depends:
+  - libdrm >=2.4.114,<2.5.0a0
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.4,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 186715
+  timestamp: 1679400122269
+- kind: conda
+  name: libvpx
+  version: 1.11.0
+  build: h9c3ff4c_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.11.0-h9c3ff4c_3.tar.bz2
+  sha256: e2c2a0bb21db1724af90cab5aa1fb3096db4c11df1ab85178571dcb8395e7a15
+  md5: ebe18273eebadbb4dfb13f1062e054e9
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1146818
+  timestamp: 1635005051234
 - kind: conda
   name: libwebp-base
   version: 1.4.0
@@ -2661,41 +3145,24 @@ packages:
 - kind: conda
   name: libxml2
   version: 2.12.7
-  build: hc051c1a_1
-  build_number: 1
+  build: he7c6b58_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
-  sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
-  md5: 340278ded8b0dc3a73f3660bbb0adbc6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-he7c6b58_4.conda
+  sha256: 10e9e0ac52b9a516a17edbc07f8d559e23778e54f1a7721b2e0e8219284fed3b
+  md5: 08a9265c637230c37cb1be4a6cad4536
   depends:
-  - icu >=73.2,<74.0a0
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 704984
-  timestamp: 1717546454837
-- kind: conda
-  name: libzlib
-  version: 1.2.13
-  build: h4ab18f5_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
-  sha256: 8ced4afed6322172182af503f21725d072a589a6eb918f8a58135c1e00d35980
-  md5: 27329162c0dc732bcf67a4e0cd488125
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - zlib 1.2.13 *_6
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 61571
-  timestamp: 1716874066944
+  size: 707169
+  timestamp: 1721031016143
 - kind: conda
   name: libzlib
   version: 1.3.1
@@ -2717,23 +3184,42 @@ packages:
   size: 56186
   timestamp: 1716874730539
 - kind: conda
-  name: llvm-openmp
-  version: 18.1.7
-  build: ha31de31_0
+  name: libzlib
+  version: 1.3.1
+  build: h4ab18f5_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.7-ha31de31_0.conda
-  sha256: 142caccdaf4cabfeb589e408c72e0e7e85ba4ae6c0d0ab5417c2a7db6f1da5a5
-  md5: 7234f31acd176e402e91e03feba90f7d
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+  sha256: adf6096f98b537a11ae3729eaa642b0811478f0ea0402ca67b5108fe2cb0010d
+  md5: 57d7dc60e9325e3de37ff8dffd18e814
   depends:
-  - libzlib >=1.2.13,<2.0a0
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 61574
+  timestamp: 1716874187109
+- kind: conda
+  name: llvm-openmp
+  version: 18.1.8
+  build: hf5423f3_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.8-hf5423f3_1.conda
+  sha256: 54b706eb3bdb1252d4fb3672d25eea4e7c66866c2a43418d895e30b34c9168ba
+  md5: 8782406a10201b67bd6476ca70cf92a8
+  depends:
+  - libzlib >=1.3.1,<2.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - openmp 18.1.7|18.1.7.*
+  - openmp 18.1.8|18.1.8.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 58663081
-  timestamp: 1717851544397
+  size: 58476497
+  timestamp: 1723605385200
 - kind: conda
   name: m2w64-gcc-libgfortran
   version: 5.3.0
@@ -2913,39 +3399,41 @@ packages:
   timestamp: 1724658547447
 - kind: conda
   name: nettle
-  version: '3.6'
-  build: he412f7d_0
+  version: 3.9.1
+  build: h7ab15ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
-  sha256: d929f0c53f2bb74c8e3d97dc1c53cc76b7cec97837fcf87998fa3dd447f03b36
-  md5: f050099af540c1c960c813b06bca89ad
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+  sha256: 1ef1b7efa69c7fb4e2a36a88316f307c115713698d1c12e19f55ae57c0482995
+  md5: 2bf1915cc107738811368afcb0993a59
   depends:
-  - libgcc-ng >=7.5.0
+  - libgcc-ng >=12
   license: GPL 2 and LGPL3
   license_family: GPL
   purls: []
-  size: 6773272
-  timestamp: 1605211080998
+  size: 1011638
+  timestamp: 1686309814836
 - kind: conda
   name: nsight-compute
-  version: 2024.1.1.4
+  version: 2022.1.1.2
   build: '0'
   subdir: linux-64
-  url: https://conda.anaconda.org/nvidia/linux-64/nsight-compute-2024.1.1.4-0.tar.bz2
-  sha256: 33935f28b007d3d5f584abd22485251ad7eea91b4b9f11c960a053fdd7be8a48
-  md5: 217ed2ff255f52cbef787aba3f9b9637
-  size: 699526661
-  timestamp: 1709778043113
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/linux-64/nsight-compute-2022.1.1.2-0.tar.bz2
+  md5: 38fd9fb0c02f0466af0e15c2cbf735c1
+  arch: x86_64
+  platform: linux
+  size: 472513783
+  timestamp: 1655332329400
 - kind: conda
   name: nsight-compute
-  version: 2024.1.1.4
+  version: 2022.1.1.2
   build: '0'
   subdir: win-64
-  url: https://conda.anaconda.org/nvidia/win-64/nsight-compute-2024.1.1.4-0.tar.bz2
-  sha256: 4c8b1724a13531fb2d745ab573413b3f230cadb598eba2aa777f2170a0dfe87a
-  md5: 4d0a3cbc76e36b490c04ae6e4115262d
-  size: 535698663
-  timestamp: 1709779654696
+  url: https://conda.anaconda.org/nvidia/label/cuda-11.6.2/win-64/nsight-compute-2022.1.1.2-0.tar.bz2
+  md5: c8df4566412db3a65ef080b4cfc717dd
+  arch: x86_64
+  platform: win
+  size: 346529176
+  timestamp: 1656437154683
 - kind: conda
   name: numpy
   version: 1.26.4
@@ -2997,21 +3485,21 @@ packages:
   timestamp: 1707226471242
 - kind: conda
   name: openh264
-  version: 2.1.1
-  build: h780b84a_0
+  version: 2.3.1
+  build: hcb278e6_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
-  sha256: 2ce3df1edb23541595443c7697e5568ae6426fa4d365dede45b16b0310bd6a06
-  md5: 034a6f90f1bbc7ba11d04b84ec9d74c8
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.3.1-hcb278e6_2.conda
+  sha256: 3be6de15d40f02c9bb34d5095c65b6b3f07e04fc21a0fb63d1885f1a31de5ae2
+  md5: 37d01894f256b2a6921c5a218f42f8a2
   depends:
-  - libgcc-ng >=9.3.0
-  - libstdcxx-ng >=9.3.0
-  - zlib >=1.2.11,<1.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 1585354
-  timestamp: 1609583081716
+  size: 718775
+  timestamp: 1675880590512
 - kind: conda
   name: openjpeg
   version: 2.5.0
@@ -3089,6 +3577,23 @@ packages:
   size: 2891789
   timestamp: 1725410790053
 - kind: conda
+  name: p11-kit
+  version: 0.24.1
+  build: hc5aa10d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+  sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
+  md5: 56ee94e34b71742bbdfa832c974e47a8
+  depends:
+  - libffi >=3.4.2,<3.5.0a0
+  - libgcc-ng >=12
+  - libtasn1 >=4.18.0,<5.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 4702497
+  timestamp: 1654868759643
+- kind: conda
   name: pillow
   version: 9.4.0
   build: py39h2320bf1_1
@@ -3164,41 +3669,23 @@ packages:
   - pkg:pypi/pip?source=hash-mapping
   size: 1237976
   timestamp: 1724954490262
-- kind: conda
+- kind: pypi
   name: portalocker
   version: 2.10.1
-  build: py39hcbf5309_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/portalocker-2.10.1-py39hcbf5309_0.conda
-  sha256: f1201cd2dce0b0618c2087f2e703d9345c7fec28493c1f56b1393e97bfa8fd47
-  md5: 32eefc9a1eea474ad26d6c03910ab2a0
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - pywin32
-  license: PSF-2.0
-  license_family: PSF
-  purls:
-  - pkg:pypi/portalocker?source=hash-mapping
-  size: 38125
-  timestamp: 1720928838336
-- kind: conda
-  name: portalocker
-  version: 2.10.1
-  build: py39hf3d152e_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/portalocker-2.10.1-py39hf3d152e_0.conda
-  sha256: a5b79f86619c5a92401436c4f0b0e20cf04642fffd5a55fb3a1d439d60d15283
-  md5: 514d9f161bc6efe6ad00cce8ccda1a04
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: PSF-2.0
-  license_family: PSF
-  purls:
-  - pkg:pypi/portalocker?source=hash-mapping
-  size: 37578
-  timestamp: 1720928656416
+  url: https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl
+  sha256: 53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf
+  requires_dist:
+  - pywin32>=226 ; platform_system == 'Windows'
+  - sphinx>=1.7.1 ; extra == 'docs'
+  - redis ; extra == 'redis'
+  - pytest>=5.4.1 ; extra == 'tests'
+  - pytest-cov>=2.8.1 ; extra == 'tests'
+  - pytest-timeout>=2.1.0 ; extra == 'tests'
+  - sphinx>=6.0.0 ; extra == 'tests'
+  - pytest-mypy>=0.8.0 ; extra == 'tests'
+  - types-redis ; extra == 'tests'
+  - redis ; extra == 'tests'
+  requires_python: '>=3.8'
 - kind: conda
   name: pthread-stubs
   version: '0.4'
@@ -3486,70 +3973,11 @@ packages:
   purls: []
   size: 2906
   timestamp: 1628062930777
-- kind: conda
+- kind: pypi
   name: pywin32
   version: '306'
-  build: py39h99910a6_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py39h99910a6_2.conda
-  sha256: bae89555b73c8bbbb9efe88490f2d16c010188dd078ed3aa39c2ba3084e31608
-  md5: eab91442160b49994dd2e224e6082770
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: PSF-2.0
-  license_family: PSF
-  purls:
-  - pkg:pypi/pywin32?source=hash-mapping
-  size: 5808124
-  timestamp: 1695974471118
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py39h8cd3c5a_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py39h8cd3c5a_1.conda
-  sha256: e07299422b0197eba5ceeef4fa76d4ee742a7f0cafcba97b91498b9764e7d990
-  md5: 76e82e62b7bda86a7fceb1f32585abad
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 181692
-  timestamp: 1725456337437
-- kind: conda
-  name: pyyaml
-  version: 6.0.2
-  build: py39ha55e580_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py39ha55e580_1.conda
-  sha256: 36ec720da777235b0775119af4d9ebbb821bb71a6c6b32b6bd4c4f6be9d895ff
-  md5: 099b4a8943b67a0a35695fa4275c0292
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyyaml?source=hash-mapping
-  size: 157276
-  timestamp: 1725456761667
+  url: https://files.pythonhosted.org/packages/1c/f7/24d8ed4fd9c43b90354df7764f81f0dd5e623f9a50f1538f90fe085d6dff/pywin32-306-cp39-cp39-win_amd64.whl
+  sha256: 39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4
 - kind: conda
   name: readline
   version: '8.2'
@@ -3608,80 +4036,55 @@ packages:
   size: 1460460
   timestamp: 1725348602179
 - kind: conda
-  name: tabulate
-  version: 0.9.0
-  build: pyhd8ed1ab_1
-  build_number: 1
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-  sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
-  md5: 4759805cce2d914c38472f70bf4d8bcb
+  name: svt-av1
+  version: 1.4.1
+  build: hcb278e6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.4.1-hcb278e6_0.conda
+  sha256: 478e8362e0234c85f7b6cbd22a45fbf9a5a84b7b7c128ab7f1ef8ff887f67981
+  md5: 2b32b8a10fa6ec9c18c897c4527720dc
   depends:
-  - python >=3.7
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/tabulate?source=hash-mapping
-  size: 35912
-  timestamp: 1665138565317
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 2488189
+  timestamp: 1670988797792
 - kind: conda
   name: tbb
-  version: 2021.12.0
-  build: h84d6215_4
-  build_number: 4
+  version: 2021.13.0
+  build: h84d6215_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h84d6215_4.conda
-  sha256: a079dcf42804a841ac2b63784f42e0d2e93401833d4a7d44ddf05b767794d578
-  md5: 1fa72fdeb88f538018612ce2ed9fc789
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.13.0-h84d6215_0.conda
+  sha256: 7d4d3ad608dc6ae5a7e0f431f784985398a18bcde2ba3ce19cc32f61e2defd98
+  md5: ee6f7fd1e76061ef1fa307d41fa86a96
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc
-  - libgcc-ng >=13
+  - libgcc >=13
   - libhwloc >=2.11.1,<2.11.2.0a0
-  - libstdcxx
-  - libstdcxx-ng >=13
+  - libstdcxx >=13
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 186953
-  timestamp: 1724905442040
+  size: 175779
+  timestamp: 1725532539822
 - kind: conda
   name: tbb
-  version: 2021.12.0
-  build: hc790b64_4
-  build_number: 4
+  version: 2021.13.0
+  build: hc790b64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_4.conda
-  sha256: d23e589311be6aeacbfb8371bd65d8637c5acc83a149baccc57d2621644fe158
-  md5: bce92c19a6cb64b47866b7271363f747
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.13.0-hc790b64_0.conda
+  sha256: 990dbe4fb42f14700c22bd434d8312607bf8d0bd9f922b054e51fda14c41994c
+  md5: 28496a1e6af43c63927da4f80260348d
   depends:
   - libhwloc >=2.11.1,<2.11.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 161921
-  timestamp: 1724906383699
-- kind: conda
-  name: termcolor
-  version: 2.4.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
-  sha256: 59588d41f2c02d599fd6528583013d85bd47d17b1acec11edbb29deadd81fbca
-  md5: a5033708ad9283907c3b1bc1f90d0d0d
-  depends:
-  - python >=3.8
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/termcolor?source=hash-mapping
-  size: 12721
-  timestamp: 1704358124294
+  size: 151494
+  timestamp: 1725532984828
 - kind: conda
   name: tk
   version: 8.6.13
@@ -3768,23 +4171,21 @@ packages:
   - pkg:pypi/torchvision?source=hash-mapping
   size: 7834301
   timestamp: 1670555591901
-- kind: conda
+- kind: pypi
   name: tqdm
   version: 4.66.5
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
-  sha256: f2384902cef72048b0e9bad5c03d7a843de02ba6bc8618a9ecab6ff81a131312
-  md5: c6e94fc2b2ec71ea33fe7c7da259acb4
-  depends:
-  - colorama
-  - python >=3.7
-  license: MPL-2.0 or MIT
-  purls:
-  - pkg:pypi/tqdm?source=hash-mapping
-  size: 89519
-  timestamp: 1722737568509
+  url: https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl
+  sha256: 90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd
+  requires_dist:
+  - colorama ; platform_system == 'Windows'
+  - pytest>=6 ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest-timeout ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - ipywidgets>=6 ; extra == 'notebook'
+  - slack-sdk ; extra == 'slack'
+  - requests ; extra == 'telegram'
+  requires_python: '>=3.7'
 - kind: conda
   name: typing_extensions
   version: 4.12.2
@@ -3941,6 +4342,92 @@ packages:
   size: 8191
   timestamp: 1667051294134
 - kind: conda
+  name: x264
+  version: 1!164.3095
+  build: h166bdaf_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+  sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
+  md5: 6c99772d483f566d59e25037fea2c4b1
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 897548
+  timestamp: 1660323080555
+- kind: conda
+  name: x265
+  version: '3.5'
+  build: h924138e_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 3357188
+  timestamp: 1646609687141
+- kind: conda
+  name: xorg-fixesproto
+  version: '5.0'
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
+  sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
+  md5: 65ad6e1eb4aed2b0611855aff05e04f6
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 9122
+  timestamp: 1617479697350
+- kind: conda
+  name: xorg-kbproto
+  version: 1.0.7
+  build: h7f98852_1002
+  build_number: 1002
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+  sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+  md5: 4b230e8381279d76131116660f5a241a
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 27338
+  timestamp: 1610027759842
+- kind: conda
+  name: xorg-libx11
+  version: 1.8.4
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
+  sha256: 3c6862a01a39cdea3870b132706ad7256824299947a3a94ae361d863d402d704
+  md5: ea8fbfeb976ac49cbeb594e985393514
+  depends:
+  - libgcc-ng >=12
+  - libxcb 1.*
+  - libxcb >=1.13,<1.14.0a0
+  - xorg-kbproto
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 829872
+  timestamp: 1677611125385
+- kind: conda
   name: xorg-libxau
   version: 1.0.11
   build: hcd874cb_0
@@ -4002,6 +4489,74 @@ packages:
   size: 67908
   timestamp: 1610072296570
 - kind: conda
+  name: xorg-libxext
+  version: 1.3.4
+  build: h0b41bf4_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+  sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+  md5: 82b6df12252e6f32402b96dacc656fec
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 50143
+  timestamp: 1677036907815
+- kind: conda
+  name: xorg-libxfixes
+  version: 5.0.3
+  build: h7f98852_1004
+  build_number: 1004
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+  sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
+  md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
+  depends:
+  - libgcc-ng >=9.3.0
+  - xorg-fixesproto
+  - xorg-libx11 >=1.7.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 18145
+  timestamp: 1617717802636
+- kind: conda
+  name: xorg-xextproto
+  version: 7.3.0
+  build: h0b41bf4_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+  sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
+  md5: bce9f945da8ad2ae9b1d7165a64d0f87
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 30270
+  timestamp: 1677036833037
+- kind: conda
+  name: xorg-xproto
+  version: 7.0.31
+  build: h7f98852_1007
+  build_number: 1007
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+  sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+  md5: b4a4381d54784606820704f7b5f05a15
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 74922
+  timestamp: 1607291557628
+- kind: conda
   name: xz
   version: 5.2.6
   build: h166bdaf_0
@@ -4030,74 +4585,6 @@ packages:
   purls: []
   size: 217804
   timestamp: 1660346976440
-- kind: conda
-  name: yacs
-  version: 0.1.8
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/yacs-0.1.8-pyhd8ed1ab_0.tar.bz2
-  sha256: f8e6834ce20458239ee26f0a67e1163570d92819ff3292c07a3dcd453fb97847
-  md5: 193eeaf8f21582929a8955ac369752b3
-  depends:
-  - python >=3.6
-  - pyyaml
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/yacs?source=hash-mapping
-  size: 17659
-  timestamp: 1645706049083
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h7f98852_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
-  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 89141
-  timestamp: 1641346969816
-- kind: conda
-  name: yaml
-  version: 0.2.5
-  build: h8ffe710_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
-  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
-  md5: adbfb9f45d1004a26763652246a33764
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 63274
-  timestamp: 1641347623319
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: h4ab18f5_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
-  sha256: 534824ea44939f3e59ca8ebb95e3ece6f50f9d2a0e69999fbc692311252ed6ac
-  md5: 559d338a4234c2ad6e676f460a093e67
-  depends:
-  - libgcc-ng >=12
-  - libzlib 1.2.13 h4ab18f5_6
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 92883
-  timestamp: 1716874088980
 - kind: conda
   name: zstandard
   version: 0.23.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -286,9 +286,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_21.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
@@ -548,6 +548,7 @@ packages:
   - python >=3.9,<3.10.0a0
   - python_abi 3.9.* *_cp39
   license: MIT
+  license_family: MIT
   purls:
   - pkg:pypi/cffi?source=hash-mapping
   size: 241610
@@ -568,6 +569,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
+  license_family: MIT
   purls:
   - pkg:pypi/cffi?source=hash-mapping
   size: 236935
@@ -4065,6 +4067,7 @@ packages:
   - libhwloc >=2.11.1,<2.11.2.0a0
   - libstdcxx >=13
   license: Apache-2.0
+  license_family: APACHE
   purls: []
   size: 175779
   timestamp: 1725532539822
@@ -4082,6 +4085,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
+  license_family: APACHE
   purls: []
   size: 151494
   timestamp: 1725532984828
@@ -4257,12 +4261,12 @@ packages:
 - kind: conda
   name: vc
   version: '14.3'
-  build: h8a93ad2_20
-  build_number: 20
+  build: h8a93ad2_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
-  sha256: 23ac5feb15a9adf3ab2b8c4dcd63650f8b7ae860c5ceb073e49cf71d203eddef
-  md5: 8558f367e1d7700554f7cdb823c46faf
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_21.conda
+  sha256: f14f5238c2e2516e292af43d91df88f212d769b4853eb46d03291793dcf00da9
+  md5: e632a9b865d4b653aa656c9fb4f4817c
   depends:
   - vc14_runtime >=14.40.33810
   track_features:
@@ -4270,42 +4274,42 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17391
-  timestamp: 1717709040616
+  size: 17243
+  timestamp: 1725984095174
 - kind: conda
   name: vc14_runtime
   version: 14.40.33810
-  build: hcc2c482_20
-  build_number: 20
+  build: ha82c5b3_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_20.conda
-  sha256: bba8daa6f78b26b48fb7e1377eb52160e25495710bf53146c5f405bd50565982
-  md5: ad33c7cd933d69b9dee0f48317cdf137
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_21.conda
+  sha256: c3bf51bff7db39ad7e890dbef1b1026df0af36975aea24dea7c5fe1e0b382c40
+  md5: b3ebb670caf046e32b835fbda056c4f9
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.40.33810.* *_20
+  - vs2015_runtime 14.40.33810.* *_21
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
   purls: []
-  size: 751028
-  timestamp: 1724712684919
+  size: 751757
+  timestamp: 1725984166774
 - kind: conda
   name: vs2015_runtime
   version: 14.40.33810
-  build: h3bf8584_20
-  build_number: 20
+  build: h3bf8584_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
-  sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
-  md5: c21f1b4a3a30bbc3ef35a50957578e0e
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_21.conda
+  sha256: 472410455c381e406ec8c1d3e0342b48ee23122ef7ffb22a09d9763ca5df4d20
+  md5: b3f37db7b7ae1c22600fa26a63ed99b3
   depends:
   - vc14_runtime >=14.40.33810
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17395
-  timestamp: 1717709043353
+  size: 17241
+  timestamp: 1725984096440
 - kind: conda
   name: wheel
   version: 0.44.0

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,4182 @@
+version: 5
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/pytorch/
+    - url: https://conda.anaconda.org/nvidia/
+    - url: https://conda.anaconda.org/iopath/
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.121-mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-21_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py39hf88036b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py39h15c3d72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl-11.6.55-hf6102b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-command-line-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-compiler-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.6.55-he381448_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-11.6.55-h42ad0f4_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cuobjdump-11.6.124-h2eeebcb_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.6.124-h86345e5_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cuxxfilt-11.6.124-hecbf4f6_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-driver-dev-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-gdb-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-dev-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-memcheck-11.8.86-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-compute-12.4.1-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-11.6.124-hbba6d2d_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvdisasm-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-11.6.55-haa9ef22_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprof-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprune-11.6.124-he22ec0a_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.6.124-h020bade_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-dev-11.6.124-h249d397_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.6.124-h0630a44_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvp-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-samples-11.6.101-h8efea70_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-toolkit-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-visual-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fvcore-0.1.5.post20221221-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/gds-tools-1.9.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcublas-12.4.5.8-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcublas-dev-12.4.5.8-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufft-11.2.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufft-dev-11.2.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.9.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.9.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.5.147-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.3.5.147-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.6.1.9-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusolver-dev-11.6.1.9-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusparse-12.3.1.170-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusparse-dev-12.3.1.170-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnpp-12.2.5.30-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnpp-dev-12.2.5.30-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-12.3.1.117-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-h4852527_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.7-ha31de31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.0.0-ha957f24_49657.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2024.0.0-ha770c72_49657.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2024.0.0-ha957f24_49657.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/nsight-compute-2024.1.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-2.10.1-py39hf3d152e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.19-h0755675_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-5_cp39.conda
+      - conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-1.13.1-py3.9_cuda11.6_cudnn8.3.2_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-cuda-11.6-h867d48c_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py39h8cd3c5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h84d6215_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/pytorch/linux-64/torchvision-0.14.1-py39_cu116.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/yacs-0.1.8-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py39h08a7858_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      - pypi: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blas-1.0-mkl.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py39ha51f57c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.0-py39ha55e580_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cccl-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-command-line-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-compiler-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-dev-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cuobjdump-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cupti-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-cuxxfilt-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-dev-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-memcheck-11.8.86-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nsight-compute-12.4.1-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvcc-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvdisasm-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvml-dev-11.6.55-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvprof-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvprune-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-dev-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvtx-11.6.124-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-nvvp-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-runtime-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-toolkit-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/cuda-visual-tools-11.6.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fvcore-0.1.5.post20221221-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jpeg-9e-hcfcfb64_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-ha5c8aab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-1_h8933c1f_netlib.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-5_hd5c7e75_netlib.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcublas-12.4.5.8-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcublas-dev-12.4.5.8-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcufft-11.2.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcufft-dev-11.2.1.3-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcurand-10.3.5.147-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcurand-dev-10.3.5.147-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcusolver-11.6.1.9-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcusolver-dev-11.6.1.9-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcusparse-12.3.1.170-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libcusparse-dev-12.3.1.170-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.17-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-5_hd5c7e75_netlib.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libnpp-12.2.5.30-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libnpp-dev-12.2.5.30-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-12.3.1.117-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.0-hf8721a0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.13-hcd874cb_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49658.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/win-64/nsight-compute-2024.1.1.4-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py39hddb5d58_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-ha2aaf27_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-9.4.0-py39hcebd2be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-2.10.1-py39hcbf5309_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.9.19-h4de0772_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.9-5_cp39.conda
+      - conda: https://conda.anaconda.org/pytorch/win-64/pytorch-1.13.1-py3.9_cuda11.6_cudnn8_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-cuda-11.6-h867d48c_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py39h99910a6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py39ha55e580_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://conda.anaconda.org/pytorch/win-64/torchvision-0.14.1-py39_cu116.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/yacs-0.1.8-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py39h9bf74da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+      - pypi: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+packages:
+- kind: conda
+  name: _libgcc_mutex
+  version: '0.1'
+  build: conda_forge
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  purls: []
+  size: 2562
+  timestamp: 1578324546067
+- kind: conda
+  name: _openmp_mutex
+  version: '4.5'
+  build: 2_kmp_llvm
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+  sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
+  md5: 562b26ba2e19059551a811e72ab7f793
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 5744
+  timestamp: 1650742457817
+- kind: conda
+  name: blas
+  version: '1.0'
+  build: mkl
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/blas-1.0-mkl.tar.bz2
+  sha256: 4d605a266a84dfb4845dcffdca741b26a8e5ec5445254a998bca1fbbc231836f
+  md5: f621d7bbe874786272e62d72c5a7b4fc
+  depends:
+  - mkl
+  arch: x86_64
+  platform: win
+  track_features:
+  - blas_mkl
+  license: BSD 3-clause
+  purls: []
+  size: 1390
+- kind: conda
+  name: blas
+  version: '2.121'
+  build: mkl
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.121-mkl.conda
+  sha256: f80817e4e85f8936d4d467abc98e1841ff47ecf98af04e67dae7ee6655fc1218
+  md5: ec030371cfa243f4983fd67d7e29e51e
+  depends:
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - blas-devel 3.9.0 21_linux64_mkl
+  - libblas 3.9.0 21_linux64_mkl
+  - libcblas 3.9.0 21_linux64_mkl
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack 3.9.0 21_linux64_mkl
+  - liblapacke 3.9.0 21_linux64_mkl
+  - llvm-openmp >=17.0.6
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14632
+  timestamp: 1705979765268
+- kind: conda
+  name: blas-devel
+  version: 3.9.0
+  build: 21_linux64_mkl
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-21_linux64_mkl.conda
+  sha256: 2de64aa8b1716eb382b06a606fc3d86f296ed6d094ad4abdef62c078884ae105
+  md5: 67684e493802a70fd14fcf4b8872ae4d
+  depends:
+  - libblas 3.9.0 21_linux64_mkl
+  - libcblas 3.9.0 21_linux64_mkl
+  - liblapack 3.9.0 21_linux64_mkl
+  - liblapacke 3.9.0 21_linux64_mkl
+  - mkl >=2024.0.0,<2025.0a0
+  - mkl-devel 2024.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14382
+  timestamp: 1705979642455
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py39ha51f57c_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py39ha51f57c_2.conda
+  sha256: e7640e3d3f742172a3a5ad40f1e2326893bd61bb51224e434f4ea509a527540a
+  md5: febb0f96eb7400bb065681117872b75e
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libbrotlicommon 1.1.0 h2466b09_2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 321820
+  timestamp: 1725268551147
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py39hf88036b_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py39hf88036b_2.conda
+  sha256: 6b5ad1d89519f926138cd146bc475d42ccbd8239849fa8677031160e17f30202
+  md5: 8ea5af6ac902f1a4429190970d9099ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 349166
+  timestamp: 1725267838006
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h2466b09_7
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 54927
+  timestamp: 1720974860185
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h4bc722e_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 252783
+  timestamp: 1720974456583
+- kind: conda
+  name: ca-certificates
+  version: 2024.8.30
+  build: h56e8100_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.8.30-h56e8100_0.conda
+  sha256: 0fcac3a7ffcc556649e034a1802aedf795e64227eaa7194d207b01eaf26454c4
+  md5: 4c4fd67c18619be5aa65dc5b6c72e490
+  license: ISC
+  purls: []
+  size: 158773
+  timestamp: 1725019107649
+- kind: conda
+  name: ca-certificates
+  version: 2024.8.30
+  build: hbcca054_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
+  sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
+  md5: c27d1c142233b5bc9ca570c6e2e0c244
+  license: ISC
+  purls: []
+  size: 159003
+  timestamp: 1725018903918
+- kind: conda
+  name: certifi
+  version: 2024.8.30
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.8.30-pyhd8ed1ab_0.conda
+  sha256: 7020770df338c45ac6b560185956c32f0a5abf4b76179c037f115fc7d687819f
+  md5: 12f7d00853807b0531775e9be891cb11
+  depends:
+  - python >=3.7
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=hash-mapping
+  size: 163752
+  timestamp: 1725278204397
+- kind: conda
+  name: cffi
+  version: 1.17.0
+  build: py39h15c3d72_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py39h15c3d72_1.conda
+  sha256: aaed3ce34c340b2cd1adbcb0a42ad5ad331f4103854b03c48d245e951138daa7
+  md5: 26236d9306b1a33b079df356ad4d07ee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 241429
+  timestamp: 1724956418269
+- kind: conda
+  name: cffi
+  version: 1.17.0
+  build: py39ha55e580_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.0-py39ha55e580_1.conda
+  sha256: ddcf4b3e61040b3ea729bec42e70f7771e4937fdd6624d7df49e3b3556e3ecc3
+  md5: 6dae6d38cce8d9cd6119b117ac0b12de
+  depends:
+  - pycparser
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 238269
+  timestamp: 1724956856273
+- kind: conda
+  name: charset-normalizer
+  version: 3.3.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=hash-mapping
+  size: 46597
+  timestamp: 1698833765762
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
+  size: 25170
+  timestamp: 1666700778190
+- kind: conda
+  name: cuda
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-11.6.2-0.tar.bz2
+  sha256: 1cee96abb344171436bdb6d6509943802164c2318a72039534f842153a45a398
+  md5: af5c0a4642b14e93d4c48aaa1076a6ba
+  depends:
+  - cuda-runtime >=11.6.2
+  - cuda-toolkit >=11.6.2
+  size: 1435
+  timestamp: 1656529490851
+- kind: conda
+  name: cuda
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-11.6.2-0.tar.bz2
+  sha256: 5a5219dcc29a97b17b31c42b277e617e5f1a1abe41915f8ede7be2579818cb76
+  md5: c6c91c7b68c7794e2b65715ac4a69479
+  depends:
+  - cuda-runtime >=11.6.2
+  - cuda-toolkit >=11.6.2
+  size: 1301
+  timestamp: 1657842551707
+- kind: conda
+  name: cuda-cccl
+  version: 11.6.55
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-cccl-11.6.55-0.tar.bz2
+  sha256: 220d6f0453f14c62bb275353aa101c4944d35db92b0872d60d1d6dcd4bae02c8
+  md5: cb596fbe733e13949ccf6971b14f4fc9
+  size: 1233766
+  timestamp: 1656445622469
+- kind: conda
+  name: cuda-cccl
+  version: 11.6.55
+  build: hf6102b2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cccl-11.6.55-hf6102b2_0.tar.bz2
+  sha256: 3d4982f613e449dcd890af09a47c21ed4eefd08214a210dbf375578a3b9b6bc3
+  md5: 6472e4cb22cdf59544d4fba86be2ec82
+  size: 1217359
+  timestamp: 1646161775316
+- kind: conda
+  name: cuda-command-line-tools
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-command-line-tools-11.6.2-0.tar.bz2
+  sha256: 737026b73d3163980e151b88944e43ad9390a56593a6b0e45ad275c3e8dede86
+  md5: b972c648560f14c72c61b57560b821cd
+  depends:
+  - cuda-cupti >=11.6.124
+  - cuda-gdb >=11.6.124
+  - cuda-memcheck >=11.6.124
+  - cuda-nvdisasm >=11.6.124
+  - cuda-nvprof >=11.6.124
+  - cuda-nvtx >=11.6.124
+  - cuda-sanitizer-api >=11.6.124
+  size: 1475
+  timestamp: 1656529349293
+- kind: conda
+  name: cuda-command-line-tools
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-command-line-tools-11.6.2-0.tar.bz2
+  sha256: 533af2473c24f0bd975d56a705d69523a100e1304a6e1097059edc7e36c9c3a7
+  md5: 585326c70cce98c204c32e4ccf5e7225
+  depends:
+  - cuda-cupti >=11.6.124
+  - cuda-memcheck >=11.6.124
+  - cuda-nvdisasm >=11.6.124
+  - cuda-nvprof >=11.6.124
+  - cuda-nvtx >=11.6.124
+  - cuda-sanitizer-api >=11.6.124
+  size: 1345
+  timestamp: 1657842430005
+- kind: conda
+  name: cuda-compiler
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-compiler-11.6.2-0.tar.bz2
+  sha256: 17b1d20faacf634d7b7cf710a5be7863264c8cf74043bcb6a07c5d1d2ec11667
+  md5: 31dd92e37e9bfa1f2158fbd60228f510
+  depends:
+  - cuda-cuobjdump >=11.6.124
+  - cuda-cuxxfilt >=11.6.124
+  - cuda-nvcc >=11.6.124
+  - cuda-nvprune >=11.6.124
+  size: 1462
+  timestamp: 1656529360983
+- kind: conda
+  name: cuda-compiler
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-compiler-11.6.2-0.tar.bz2
+  sha256: 953663b46d172a93a37df855ed63c1e0de2b1e364457ae7efeb8c2e4f1ea6aad
+  md5: 0fe3bdd59239873f18b24ca8ee07630e
+  depends:
+  - cuda-cuobjdump >=11.6.124
+  - cuda-cuxxfilt >=11.6.124
+  - cuda-nvcc >=11.6.124
+  - cuda-nvprune >=11.6.124
+  size: 1329
+  timestamp: 1657842441070
+- kind: conda
+  name: cuda-cudart
+  version: 11.6.55
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-11.6.55-0.tar.bz2
+  sha256: 30801d86f54c5edda04189eee123ff4d07f7d31f1bce71a76be92c9ab0fb61dd
+  md5: 347b92a621d34ac5689621b17d8b2555
+  size: 1507570
+  timestamp: 1657571025013
+- kind: conda
+  name: cuda-cudart
+  version: 11.6.55
+  build: he381448_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.6.55-he381448_0.tar.bz2
+  sha256: 4d2d29cb3bed7c33d32403f06452ef4b0023d586443c710845c326cb0d66cef0
+  md5: 1d656e60710e5b25778e33b380e478e9
+  size: 198348
+  timestamp: 1639795847364
+- kind: conda
+  name: cuda-cudart-dev
+  version: 11.6.55
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-cudart-dev-11.6.55-0.tar.bz2
+  sha256: 27fd441f3ede0fa49f59b7f28618e57ea51e96e8f0e4de43fd0f0d1443096b95
+  md5: 1ab6ddbb686c76251f6a644c2b1c8001
+  depends:
+  - cuda-cccl
+  - cuda-cudart >=11.6.55
+  size: 688234
+  timestamp: 1657571077840
+- kind: conda
+  name: cuda-cudart-dev
+  version: 11.6.55
+  build: h42ad0f4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-dev-11.6.55-h42ad0f4_0.tar.bz2
+  sha256: aad603c802c14daf5b97d9eec042a6cd7c50675c0a22b50744387877c39b72d4
+  md5: 315b5b998a6b75e89de63279afea28f8
+  depends:
+  - cuda-cccl
+  - cuda-cudart >=11.6.55
+  size: 1064044
+  timestamp: 1639795848386
+- kind: conda
+  name: cuda-cuobjdump
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-cuobjdump-11.6.124-0.tar.bz2
+  sha256: 87b66408e5225368911e3cd06cc9b23b701ea44a6acb5a17e01d1dc6c32f4eb2
+  md5: a4b568d86f310406b15f343f05e62ff0
+  size: 2606856
+  timestamp: 1656529869765
+- kind: conda
+  name: cuda-cuobjdump
+  version: 11.6.124
+  build: h2eeebcb_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cuobjdump-11.6.124-h2eeebcb_0.tar.bz2
+  sha256: bc03e2e64b56c52880801afc8fcb394ac07c3bafcd3f3c9ddbfd156b4c7de0ba
+  md5: 5fef1e10de86c8f33bee28bb59d43c9c
+  size: 137528
+  timestamp: 1646799366613
+- kind: conda
+  name: cuda-cupti
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-cupti-11.6.124-0.tar.bz2
+  sha256: 635d4c6dbf5fc0053792c7f11b9ff61b32aa9c574e50f49aa275101ed16e06c4
+  md5: 5589c69dd83b78cbfd050f179584a457
+  size: 10501677
+  timestamp: 1657823921791
+- kind: conda
+  name: cuda-cupti
+  version: 11.6.124
+  build: h86345e5_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.6.124-h86345e5_0.tar.bz2
+  sha256: 989d85df8eb6bf2e2a8c42b9dac456841a9a109547c0ad670e0de7b785239483
+  md5: 53238c87653898e83b6cd0f072fafec7
+  size: 23210814
+  timestamp: 1646800069888
+- kind: conda
+  name: cuda-cuxxfilt
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-cuxxfilt-11.6.124-0.tar.bz2
+  sha256: 193dd4e19b38fe7bafc7399a53a530316f136188e542c152803fc45d9efbc727
+  md5: 42dac2069ecaac20121470efe9a3580f
+  size: 169057
+  timestamp: 1657835994062
+- kind: conda
+  name: cuda-cuxxfilt
+  version: 11.6.124
+  build: hecbf4f6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cuxxfilt-11.6.124-hecbf4f6_0.tar.bz2
+  sha256: 82987f062af4005715850444598f3dde2d59775c818c896dd3a7017840e382f3
+  md5: 10d374991b52d605a36f194997fe44b6
+  size: 289994
+  timestamp: 1646796211378
+- kind: conda
+  name: cuda-driver-dev
+  version: 11.6.55
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-driver-dev-11.6.55-0.tar.bz2
+  sha256: 6674d114ba0f80eb33db7a4a15c53be07528b49bcb78dfa7da05e3b00a765bd9
+  md5: 6fea0593b9fdb4b7ad15817594134d21
+  size: 16838
+  timestamp: 1639795847941
+- kind: conda
+  name: cuda-gdb
+  version: 12.4.127
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-gdb-12.4.127-0.tar.bz2
+  sha256: b66f62901a846328bf999be246098ff9dc07fb098b089fe995cc7a6b7b0eb664
+  md5: f36a1e5fef08c9980991e3ed27fcd644
+  size: 6056326
+  timestamp: 1710546537965
+- kind: conda
+  name: cuda-libraries
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.6.2-0.tar.bz2
+  sha256: 6315f9f074d2e8fb7dfa6a1833c96db524430b69cf64dfff393cff0ab1560b06
+  md5: abfbf487c341ae21cfbb62e6606d96c6
+  depends:
+  - cuda-cudart >=11.6.55
+  - cuda-nvrtc >=11.6.124
+  - libcublas >=11.9.2.110
+  - libcufft >=10.7.2.124
+  - libcufile >=1.2.1.4
+  - libcurand >=10.2.9.124
+  - libcusolver >=11.3.4.124
+  - libcusparse >=11.7.2.124
+  - libnpp >=11.6.3.124
+  - libnvjpeg >=11.6.2.124
+  size: 1540
+  timestamp: 1656529373038
+- kind: conda
+  name: cuda-libraries
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-11.6.2-0.tar.bz2
+  sha256: ec5089b875d027fec2732a2257d9ce8c4574d9b8d4528877ea32e018aa45cd2a
+  md5: 57b8a01ffc3dae55e3a5f9d9d8ee0b78
+  depends:
+  - cuda-cudart >=11.6.55
+  - cuda-nvrtc >=11.6.124
+  - libcublas >=11.9.2.110
+  - libcufft >=10.7.2.124
+  - libcurand >=10.2.9.124
+  - libcusolver >=11.3.4.124
+  - libcusparse >=11.7.2.124
+  - libnpp >=11.6.3.124
+  - libnvjpeg >=11.6.2.124
+  size: 1366
+  timestamp: 1657842452324
+- kind: conda
+  name: cuda-libraries-dev
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-dev-11.6.2-0.tar.bz2
+  sha256: abcf5ae7332ece32e3487e4c30881ad76d55c8198cd7b0dabac11edf6655754c
+  md5: 70a3d479be7ab1a743564b991a1adbe3
+  depends:
+  - cuda-cccl >=11.6.55
+  - cuda-cudart-dev >=11.6.55
+  - cuda-driver-dev >=11.6.55
+  - cuda-nvrtc-dev >=11.6.124
+  - libcublas-dev >=11.9.2.110
+  - libcufft-dev >=10.7.2.124
+  - libcufile-dev >=1.2.1.4
+  - libcurand-dev >=10.2.9.124
+  - libcusolver-dev >=11.3.4.124
+  - libcusparse-dev >=11.7.2.124
+  - libnpp-dev >=11.6.3.124
+  - libnvjpeg-dev >=11.6.2.124
+  size: 1538
+  timestamp: 1656529385483
+- kind: conda
+  name: cuda-libraries-dev
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-libraries-dev-11.6.2-0.tar.bz2
+  sha256: 02c49b4a03e37fba0aacc0651fdf80e68367f7c06de4ef2145fbe6d1da89dd6a
+  md5: a3b1559098066232c5ee3bd07fb6faf5
+  depends:
+  - cuda-cccl >=11.6.55
+  - cuda-cudart-dev >=11.6.55
+  - cuda-nvrtc-dev >=11.6.124
+  - libcublas-dev >=11.9.2.110
+  - libcufft-dev >=10.7.2.124
+  - libcurand-dev >=10.2.9.124
+  - libcusolver-dev >=11.3.4.124
+  - libcusparse-dev >=11.7.2.124
+  - libnpp-dev >=11.6.3.124
+  - libnvjpeg-dev >=11.6.2.124
+  size: 1389
+  timestamp: 1657842463980
+- kind: conda
+  name: cuda-memcheck
+  version: 11.8.86
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-memcheck-11.8.86-0.tar.bz2
+  sha256: f8c3684e78956815a07411b78eb8b7a26b9778dbcd3c03376ae0fc66cec85e81
+  md5: 0d658b7c0e0799af3a981eff1c33771c
+  size: 171911
+  timestamp: 1661470265954
+- kind: conda
+  name: cuda-memcheck
+  version: 11.8.86
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-memcheck-11.8.86-0.tar.bz2
+  sha256: 0386ac65caee745ebe864e89b62a2efe7f4af7feeb452d349435bb81c6cc2757
+  md5: af2ac23440715e346977009696c60c5e
+  size: 187077
+  timestamp: 1661486161008
+- kind: conda
+  name: cuda-nsight
+  version: 12.4.127
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-12.4.127-0.tar.bz2
+  sha256: 809499163a96812af3a2a4058cdf7affc1c638eabf255e6f39efdcd75a67f3eb
+  md5: 031e25cc0010cecfa62249acc3939ee6
+  size: 119222580
+  timestamp: 1710541146699
+- kind: conda
+  name: cuda-nsight-compute
+  version: 12.4.1
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nsight-compute-12.4.1-0.tar.bz2
+  sha256: 669cd54c2cca10d3c47c5ed1ca9d9d0fce03c081bbc8af2ba695f1f589284ea7
+  md5: 72b772f260afa08d99ef2fd15f035739
+  depends:
+  - nsight-compute >=2024.1.1.4
+  size: 1847
+  timestamp: 1711654532367
+- kind: conda
+  name: cuda-nsight-compute
+  version: 12.4.1
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nsight-compute-12.4.1-0.tar.bz2
+  sha256: bf2a7a81ab4cffb06bc29412f6673ac6055993c8126f252f863e45dde30b11ea
+  md5: c0c780a71011d05c3e40f44f7606656d
+  depends:
+  - nsight-compute >=2024.1.1.4
+  size: 1769
+  timestamp: 1711654698530
+- kind: conda
+  name: cuda-nvcc
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvcc-11.6.124-0.tar.bz2
+  sha256: 465baefb281150e29452a6cec1b295e4ad550132369c171a6e8d3aa10aece2f5
+  md5: e1934c1e58959b76af20771558153b4d
+  size: 45500858
+  timestamp: 1657836312614
+- kind: conda
+  name: cuda-nvcc
+  version: 11.6.124
+  build: hbba6d2d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvcc-11.6.124-hbba6d2d_0.tar.bz2
+  sha256: b15a978e93e8b4a1f51b9cb52fdf9cf36c15471e7fd7817356917dfeb15e29fa
+  md5: b43d7b24ed402cdd5e4c1c1238645768
+  size: 44292444
+  timestamp: 1646799612290
+- kind: conda
+  name: cuda-nvdisasm
+  version: 12.4.127
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvdisasm-12.4.127-0.tar.bz2
+  sha256: 2635c44a557ab45c46265e9af7694d00956f6bd8c031d5a10da83e6472d26aae
+  md5: 2011077477fc67866170f04bcac0dcd0
+  size: 50215513
+  timestamp: 1710544140559
+- kind: conda
+  name: cuda-nvdisasm
+  version: 12.4.127
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvdisasm-12.4.127-0.tar.bz2
+  sha256: 58d9cebf5f70d1dcc41fdc14150ffe045bd0ec6b1e5f91ef5a8cd0a1395d3590
+  md5: 3a90f35980872cb4fd34d7a5abba6dbe
+  size: 50383331
+  timestamp: 1710545430171
+- kind: conda
+  name: cuda-nvml-dev
+  version: 11.6.55
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvml-dev-11.6.55-0.tar.bz2
+  sha256: aed64eba589e337fb819adc5e9e2b61c40fb455761efeb0a705a897c707da904
+  md5: c6457481b5431e4b20179950a2136e46
+  size: 85009
+  timestamp: 1657833217709
+- kind: conda
+  name: cuda-nvml-dev
+  version: 11.6.55
+  build: haa9ef22_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvml-dev-11.6.55-haa9ef22_0.tar.bz2
+  sha256: 404defa489fe2e95ef620b9746aae4bbb49e21a07a796322c6c362b76dcc904f
+  md5: 46f4a1cdf2fb9a21dc4f1abe51c4df5c
+  size: 66704
+  timestamp: 1639797040268
+- kind: conda
+  name: cuda-nvprof
+  version: 12.4.127
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprof-12.4.127-0.tar.bz2
+  sha256: 75597b69222f52c0de92e72f0431b133a2ac6945dc3456f3a4c2c9da4681f0f3
+  md5: bfdbdb5a65e35ef10ca14723de7fd9b5
+  size: 4960988
+  timestamp: 1710549514085
+- kind: conda
+  name: cuda-nvprof
+  version: 12.4.127
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvprof-12.4.127-0.tar.bz2
+  sha256: b1ab077d9f77cab9efdcbff1da6c78da0267d526e832c64ac611bd8c8095f70d
+  md5: 789785beacc557c880f20b68b759a06b
+  size: 1686518
+  timestamp: 1710546076324
+- kind: conda
+  name: cuda-nvprune
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvprune-11.6.124-0.tar.bz2
+  sha256: 407e6a24ea0e0b46305adf3ef8bba3d5e0582c0ed46085674f3114854e27ea52
+  md5: 794ee3f4f2c9021a4096b608cb64de2d
+  size: 155124
+  timestamp: 1656527711217
+- kind: conda
+  name: cuda-nvprune
+  version: 11.6.124
+  build: he22ec0a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvprune-11.6.124-he22ec0a_0.tar.bz2
+  sha256: de0df40712ea69f32e0ba999923fd97262e805be6948d0f8fca2ead2d9d6f9cd
+  md5: 6e26d5a4e36ef88e6b5db2b4e6ffda70
+  size: 66461
+  timestamp: 1646796467738
+- kind: conda
+  name: cuda-nvrtc
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-11.6.124-0.tar.bz2
+  sha256: 2da898e5de255f507cf706cd9336840d38a30f3a52e05c1049228b17841a17f5
+  md5: 608076e88e5b2e57aa34a7f53201439f
+  size: 74878113
+  timestamp: 1657033857169
+- kind: conda
+  name: cuda-nvrtc
+  version: 11.6.124
+  build: h020bade_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.6.124-h020bade_0.tar.bz2
+  sha256: 0615731e56b85baf89c442fa1709281788ae5f87b6b4b7f15405eb0978d24ec1
+  md5: ea24ed9c8891eaf179529ca7848c5f88
+  size: 17963406
+  timestamp: 1646799392929
+- kind: conda
+  name: cuda-nvrtc-dev
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvrtc-dev-11.6.124-0.tar.bz2
+  sha256: 13f1bc7b20d1b5b2082c41ac7d5cb90a092e885b383195e98bdcb5c9f73ee150
+  md5: e01e07ea81dd15646052677add566f9b
+  depends:
+  - cuda-nvrtc >=11.6.124
+  size: 14963244
+  timestamp: 1657033945716
+- kind: conda
+  name: cuda-nvrtc-dev
+  version: 11.6.124
+  build: h249d397_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-dev-11.6.124-h249d397_0.tar.bz2
+  sha256: 70d0b59a7f3a882821a03298153120cf9fecb21756ebe41637e2b4d976bec539
+  md5: 650c3307c916c6442f7d39ffd243f1e7
+  depends:
+  - cuda-nvrtc >=11.6.124
+  size: 17619671
+  timestamp: 1646799404215
+- kind: conda
+  name: cuda-nvtx
+  version: 11.6.124
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvtx-11.6.124-0.tar.bz2
+  sha256: 3809360856d019d4279809ba52297060caf8c6f7094d0024d0620558f2785280
+  md5: 2748bd39f79839cefe0f87dd83758d36
+  size: 43948
+  timestamp: 1656615267248
+- kind: conda
+  name: cuda-nvtx
+  version: 11.6.124
+  build: h0630a44_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.6.124-h0630a44_0.tar.bz2
+  sha256: 94bd25354cc82150800cdcda21606453019c0385b5657a3bc2788fe64092d510
+  md5: ca92d5a3fe901d9ff81500aeb823ba49
+  size: 59449
+  timestamp: 1646799363177
+- kind: conda
+  name: cuda-nvvp
+  version: 12.4.127
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvvp-12.4.127-0.tar.bz2
+  sha256: dad5b6a981d34ea7886928e62ee860d82274d996c824ac9ce0e0682bfc138da0
+  md5: fe0f1f926bd04b7468df9d6c991d7b77
+  depends:
+  - cuda-nvdisasm
+  - cuda-nvprof
+  size: 120069229
+  timestamp: 1710550059475
+- kind: conda
+  name: cuda-nvvp
+  version: 12.4.127
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-nvvp-12.4.127-0.tar.bz2
+  sha256: 4e7453cc3cacc562be617ede11f439faf8aafa25bcef83d8c59bff0c6e441fd5
+  md5: 71c90ca533a9a0e7ac6635d44f7ab8b1
+  depends:
+  - cuda-nvdisasm
+  - cuda-nvprof
+  size: 119132361
+  timestamp: 1710547781188
+- kind: conda
+  name: cuda-runtime
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.6.2-0.tar.bz2
+  sha256: b8f8f5958929f23a603bcbfe2a5a693e0ff93e47ef60187aef32e282ffb0de2d
+  md5: f5f915d12e7fdcb91c6ee5f5b7b39e2a
+  depends:
+  - cuda-libraries >=11.6.2
+  size: 1429
+  timestamp: 1656529432372
+- kind: conda
+  name: cuda-runtime
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-runtime-11.6.2-0.tar.bz2
+  sha256: 90ee5cac80a67f7974601596b7e8855bfde6feecdc7f57b4299aade896106638
+  md5: d67290294337ae55071dde31c03882c3
+  depends:
+  - cuda-libraries >=11.6.2
+  size: 1298
+  timestamp: 1657842507764
+- kind: conda
+  name: cuda-samples
+  version: 11.6.101
+  build: h8efea70_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-samples-11.6.101-h8efea70_0.tar.bz2
+  sha256: 44965e8259962f864403db17c8d6370fc587770a02efafa1ed4a562fb1416652
+  md5: 178b1f759964c67d2e6906ac77b02e49
+  size: 5294
+  timestamp: 1636576605917
+- kind: conda
+  name: cuda-sanitizer-api
+  version: 12.4.127
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
+  sha256: 479ef4c2877f59d11b4125b7e4147d1aa226906975544904022076491bf20b9f
+  md5: 3d8b2d25db78ccdbe63cae75f8056a8d
+  size: 17962299
+  timestamp: 1710553494409
+- kind: conda
+  name: cuda-sanitizer-api
+  version: 12.4.127
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-sanitizer-api-12.4.127-0.tar.bz2
+  sha256: 95844dc0ca7c7f6d646ce42713348f409f2632563348be6204c0800ce77c0109
+  md5: e006f8eadbf564b769f11fc833ad07a5
+  size: 13808433
+  timestamp: 1710544035417
+- kind: conda
+  name: cuda-toolkit
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-toolkit-11.6.2-0.tar.bz2
+  sha256: 498c7fb8fd4ab4a834b6d76469d2ad57a3d109f4b8adf7949c9771f21df1eb6d
+  md5: ecb8389ea291cc57c80d22625b2307dc
+  depends:
+  - cuda-compiler >=11.6.2
+  - cuda-libraries >=11.6.2
+  - cuda-libraries-dev >=11.6.2
+  - cuda-nvml-dev >=11.6.55
+  - cuda-samples >=11.6.101
+  - cuda-tools >=11.6.2
+  size: 1471
+  timestamp: 1656529467544
+- kind: conda
+  name: cuda-toolkit
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-toolkit-11.6.2-0.tar.bz2
+  sha256: fa6579510cb7b79fca240163665e3feab4e32ecea0080e97800b2834a0bfa4cd
+  md5: a159048e84f6debd212947ff6a34b900
+  depends:
+  - cuda-compiler >=11.6.2
+  - cuda-libraries >=11.6.2
+  - cuda-libraries-dev >=11.6.2
+  - cuda-nvml-dev >=11.6.55
+  - cuda-tools >=11.6.2
+  size: 1334
+  timestamp: 1657842540971
+- kind: conda
+  name: cuda-tools
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-tools-11.6.2-0.tar.bz2
+  sha256: 54cafb8e852a9035ff90ed372f9afff16e96368d8bdb497967fbe4feb91ca5b7
+  md5: ddcd6d63faa8f867ab9862cef7618a91
+  depends:
+  - cuda-command-line-tools >=11.6.2
+  - cuda-visual-tools >=11.6.2
+  - gds-tools >=1.2.1.4
+  size: 1452
+  timestamp: 1656529455847
+- kind: conda
+  name: cuda-tools
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-tools-11.6.2-0.tar.bz2
+  sha256: b89b71d5635db763b31db54b224f26108e36c541b77da2934b2ff03e4c9d763d
+  md5: c4a069a22142209f6445bb6429d8669d
+  depends:
+  - cuda-command-line-tools >=11.6.2
+  - cuda-visual-tools >=11.6.2
+  size: 1314
+  timestamp: 1657842529942
+- kind: conda
+  name: cuda-visual-tools
+  version: 11.6.2
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-visual-tools-11.6.2-0.tar.bz2
+  sha256: 24ab2459710a89a48cf0f1cd470bb154fea4577e5a2c97f553e98b39912db0fa
+  md5: d180f95176c7efb6f9bd11a3fbf88218
+  depends:
+  - cuda-libraries-dev >=11.6.2
+  - cuda-nsight >=11.6.124
+  - cuda-nsight-compute >=11.6.2
+  - cuda-nvml-dev >=11.6.55
+  - cuda-nvvp >=11.6.124
+  size: 1484
+  timestamp: 1656529444052
+- kind: conda
+  name: cuda-visual-tools
+  version: 11.6.2
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/cuda-visual-tools-11.6.2-0.tar.bz2
+  sha256: 4389f541556a347963e92117a049905a537a1cd684761baf81fe27090c04ac85
+  md5: a804f7945bd167de997b57a0d86ea7e6
+  depends:
+  - cuda-libraries-dev >=11.6.2
+  - cuda-nsight-compute >=11.6.2
+  - cuda-nvml-dev >=11.6.55
+  - cuda-nvvp >=11.6.124
+  size: 1341
+  timestamp: 1657842518654
+- kind: conda
+  name: ffmpeg
+  version: '4.3'
+  build: hf484d3e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
+  sha256: 60b3e36cb36b706f5850f155bd9d3f33194a522b5ef20be46cb37dbc987a6741
+  md5: 0b0bf7c3d7e146ef91de5310bbf7a230
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - freetype >=2.10.2,<3.0a0
+  - gmp >=6.1.2
+  - gnutls >=3.6.5,<3.7.0a0
+  - lame >=3.100,<3.101.0a0
+  - libgcc-ng >=7.3.0
+  - libiconv
+  - libstdcxx-ng >=7.3.0
+  - openh264 >=2.1.0,<2.2.0a0
+  - zlib >=1.2.11,<1.3.0a0
+  license: LGPL
+  purls: []
+  size: 10426878
+  timestamp: 1596130242227
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: h267a509_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 634972
+  timestamp: 1694615932610
+- kind: conda
+  name: freetype
+  version: 2.12.1
+  build: hdaf720e_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+  sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
+  md5: 3761b23693f768dc75a8fd0a73ca053f
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 510306
+  timestamp: 1694616398888
+- kind: conda
+  name: fvcore
+  version: 0.1.5.post20221221
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/fvcore-0.1.5.post20221221-pyhd8ed1ab_0.conda
+  sha256: 642838ed0ef162ff3ae5817971b5cb5d452c73d655bfa384adecb8f268619e01
+  md5: 0a0797787d4c8d9f7b767da76774efad
+  depends:
+  - numpy
+  - pillow
+  - portalocker
+  - python >=3.6
+  - pyyaml >=5.1
+  - tabulate
+  - termcolor >=1.1
+  - tqdm
+  - yacs >=0.1.6
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/fvcore?source=hash-mapping
+  size: 60175
+  timestamp: 1671623775701
+- kind: conda
+  name: gds-tools
+  version: 1.9.1.3
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/gds-tools-1.9.1.3-0.tar.bz2
+  sha256: 786e251ef09733a120829baa842ba9ba60d1598f10475a2962c5a7597426ae55
+  md5: c434e7cafa6663ecf3953f00a099ac23
+  depends:
+  - libcufile >=1.9.1.3
+  size: 42707168
+  timestamp: 1710365911168
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: hac33072_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  size: 460055
+  timestamp: 1718980856608
+- kind: conda
+  name: gnutls
+  version: 3.6.13
+  build: h85f3911_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+  sha256: 6c9307f0fedce2c4d060bba9ac888b300bc0912effab423d67b8e1b661a93305
+  md5: 7d1b6fff16c1431d96cb4934938799fd
+  depends:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  - nettle >=3.4.1
+  - nettle >=3.6,<3.7.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 2096527
+  timestamp: 1605742597225
+- kind: conda
+  name: h2
+  version: 4.1.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+  md5: b748fbf7060927a6e82df7cb5ee8f097
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.6.1
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h2?source=hash-mapping
+  size: 46754
+  timestamp: 1634280590080
+- kind: conda
+  name: hpack
+  version: 4.0.0
+  build: pyh9f0ad1d_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
+  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
+  md5: 914d6646c4dbb1fd3ff539830a12fd71
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hpack?source=hash-mapping
+  size: 25341
+  timestamp: 1598856368685
+- kind: conda
+  name: hyperframe
+  version: 6.0.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
+  md5: 9f765cbfab6870c8435b9eefecd7a1f4
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hyperframe?source=hash-mapping
+  size: 14646
+  timestamp: 1619110249723
+- kind: conda
+  name: icu
+  version: '73.2'
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+  sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+  md5: cc47e1facc155f91abd89b11e48e72ff
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12089150
+  timestamp: 1692900650789
+- kind: conda
+  name: idna
+  version: '3.8'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
+  sha256: 8660d38b272d3713ec8ac5ae918bc3bc80e1b81e1a7d61df554bded71ada6110
+  md5: 99e164522f6bdf23c177c8d9ae63f975
+  depends:
+  - python >=3.6
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=hash-mapping
+  size: 49275
+  timestamp: 1724450633325
+- kind: conda
+  name: intel-openmp
+  version: 2024.2.1
+  build: h57928b3_1083
+  build_number: 1083
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  size: 1852356
+  timestamp: 1723739573141
+- kind: pypi
+  name: iopath
+  version: 0.1.10
+  url: https://files.pythonhosted.org/packages/72/73/b3d451dfc523756cf177d3ebb0af76dc7751b341c60e2a21871be400ae29/iopath-0.1.10.tar.gz
+  sha256: 3311c16a4d9137223e20f141655759933e1eda24f8bff166af834af3c645ef01
+  requires_dist:
+  - tqdm
+  - typing-extensions
+  - portalocker
+  - dataclasses ; python_full_version < '3.7'
+  - boto3 ; extra == 'aws'
+  requires_python: '>=3.6'
+- kind: conda
+  name: jpeg
+  version: 9e
+  build: h0b41bf4_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+  sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
+  md5: c7a069243e1fbe9a556ed2ec030e6407
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libjpeg-turbo <0.0.0a
+  license: IJG
+  purls: []
+  size: 240359
+  timestamp: 1676177310738
+- kind: conda
+  name: jpeg
+  version: 9e
+  build: hcfcfb64_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/jpeg-9e-hcfcfb64_3.conda
+  sha256: 7ee2ecbb5fe11566601e612fa463fc2060e55083d9cb1eb05c58e30a9e110b41
+  md5: 824f1e030d224e9e376a4655032fdbc7
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  constrains:
+  - libjpeg-turbo <0.0.0a
+  license: IJG
+  purls: []
+  size: 289378
+  timestamp: 1676178492989
+- kind: conda
+  name: lame
+  version: '3.100'
+  build: h166bdaf_1003
+  build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+  md5: a8832b479f93521a9e7b5b743803be51
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.0-only
+  license_family: LGPL
+  purls: []
+  size: 508258
+  timestamp: 1664996250081
+- kind: conda
+  name: lcms2
+  version: '2.15'
+  build: ha5c8aab_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-ha5c8aab_0.conda
+  sha256: 77a232675ac1199b8eb8789fc3f541dea4de97c7bf4c4861f3857e770a9a8915
+  md5: 5ebe92728f44a8b2461410ffb3628c18
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.0,<4.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 498449
+  timestamp: 1678105052633
+- kind: conda
+  name: lcms2
+  version: '2.15'
+  build: hfd0df8a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
+  sha256: 443e926b585528112ec6aa4d85bf087722914ed8d85a2f75ae47c023c55c4238
+  md5: aa8840cdf17ef0c6084d1e24abc7a28b
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=12
+  - libtiff >=4.5.0,<4.6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 240794
+  timestamp: 1678211140434
+- kind: conda
+  name: ld_impl_linux-64
+  version: '2.40'
+  build: hf3520f5_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+  sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
+  md5: b80f2f396ca2c28b8c14c437a4ed1e74
+  constrains:
+  - binutils_impl_linux-64 2.40
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 707602
+  timestamp: 1718625640445
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 281798
+  timestamp: 1657977462600
+- kind: conda
+  name: lerc
+  version: 4.0.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+  sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
+  md5: 1900cb3cab5055833cfddb0ba233b074
+  depends:
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 194365
+  timestamp: 1657977692274
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 1_h8933c1f_netlib
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-1_h8933c1f_netlib.tar.bz2
+  sha256: 250eb1a9b62490514a61aa0efc62638f44f6f3b7acd80b4b8eff66bd7319ce2c
+  md5: 2c5ff3ea7416bb5edc70e67f4ee1ff71
+  depends:
+  - m2w64-gcc-libs
+  track_features:
+  - blas_netlib
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 198075
+  timestamp: 1603053118509
+- kind: conda
+  name: libblas
+  version: 3.9.0
+  build: 21_linux64_mkl
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-21_linux64_mkl.conda
+  sha256: ebdd80bbb4421370e071076ccb1224a1d8b0137364c8a12fa84740cd60121789
+  md5: f7b5c949cec73aa6a56f5b6a295f7301
+  depends:
+  - mkl >=2024.0.0,<2025.0a0
+  constrains:
+  - libcblas 3.9.0 21_linux64_mkl
+  - liblapacke 3.9.0 21_linux64_mkl
+  - blas * mkl
+  - liblapack 3.9.0 21_linux64_mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 15055
+  timestamp: 1705979579453
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 21_linux64_mkl
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-21_linux64_mkl.conda
+  sha256: 072f83a0d7b35efd48a5f17e973d584a8352b624cc7bc0fdb9c48ad39baf3984
+  md5: 0553cad80ef02be86c8e178eeecb6a34
+  depends:
+  - libblas 3.9.0 21_linux64_mkl
+  constrains:
+  - liblapacke 3.9.0 21_linux64_mkl
+  - blas * mkl
+  - liblapack 3.9.0 21_linux64_mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14561
+  timestamp: 1705979595754
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 5_hd5c7e75_netlib
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-5_hd5c7e75_netlib.tar.bz2
+  sha256: a0bf6ff5894026ef4437a7ec9f30e9be97e4f8c2772abf2bba6cd28028701318
+  md5: 4bc72746442cbfa257ceb7c91ee797d1
+  depends:
+  - libblas 3.9.0.*
+  - m2w64-gcc-libs
+  track_features:
+  - blas_netlib
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 97729
+  timestamp: 1618013041863
+- kind: conda
+  name: libcublas
+  version: 12.4.5.8
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-12.4.5.8-0.tar.bz2
+  sha256: 341dcb4c3bdc2a105d9352e8cddb5011dbf5c7bfedb5930fb5bae2dedb6d5c02
+  md5: 1ca600f8d1329496d8c21c904be007dc
+  size: 324199551
+  timestamp: 1711452729415
+- kind: conda
+  name: libcublas
+  version: 12.4.5.8
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcublas-12.4.5.8-0.tar.bz2
+  sha256: 45536c2176e79a02d52d9347a6888cd8a44a590f7fe02319106d889fd7341447
+  md5: f0c09cc7daea6c4f88447948e582b778
+  size: 35171
+  timestamp: 1711455085444
+- kind: conda
+  name: libcublas-dev
+  version: 12.4.5.8
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-dev-12.4.5.8-0.tar.bz2
+  sha256: 4d5de328af7e1a2ca0bb099fb67c3cf6535a1710a67857951203c375d588617f
+  md5: 3f4a986f221f132d77d5b421fda721c0
+  depends:
+  - libcublas >=12.4.5.8
+  size: 76659
+  timestamp: 1711452843192
+- kind: conda
+  name: libcublas-dev
+  version: 12.4.5.8
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcublas-dev-12.4.5.8-0.tar.bz2
+  sha256: 32747ea55f66df4d059275d0a137f4436ee2deb34d733992b7ca9a6c783cb98c
+  md5: 4cef35b1d916d30c81b0cf05e7b36327
+  depends:
+  - libcublas >=12.4.5.8
+  size: 361381245
+  timestamp: 1711455367600
+- kind: conda
+  name: libcufft
+  version: 11.2.1.3
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-11.2.1.3-0.tar.bz2
+  sha256: ddca1aedf91e825e688e4d982a25c569fe215d69814f63db350c16d693f3eac8
+  md5: 19d9ed3642b9be9ca2565f52ed5ce787
+  size: 199783504
+  timestamp: 1710543633676
+- kind: conda
+  name: libcufft
+  version: 11.2.1.3
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcufft-11.2.1.3-0.tar.bz2
+  sha256: b349231aa80555fa576d06bac443b57fac2cd81787c20e661e2f0e9d57bc2ae5
+  md5: dc06b183f8f738201bc2596f83998d83
+  size: 6086
+  timestamp: 1710546148766
+- kind: conda
+  name: libcufft-dev
+  version: 11.2.1.3
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-dev-11.2.1.3-0.tar.bz2
+  sha256: 2dfb413fb3375561523720c41efcaba70508cd5327c56d34fcfd55dfa6081972
+  md5: 8f30ed45d91f27edab17e53f74feae99
+  depends:
+  - libcufft >=11.2.1.3
+  size: 14754
+  timestamp: 1710543692819
+- kind: conda
+  name: libcufft-dev
+  version: 11.2.1.3
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcufft-dev-11.2.1.3-0.tar.bz2
+  sha256: c1c0f3f5d936bc2ced7990f653d688e7c0c25bad24510c764124172918e74981
+  md5: cf314f36b8ece1e6930ac998b8fa22aa
+  depends:
+  - libcufft >=11.2.1.3
+  size: 198753382
+  timestamp: 1710546296741
+- kind: conda
+  name: libcufile
+  version: 1.9.1.3
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.9.1.3-0.tar.bz2
+  sha256: e820395b70a93832a3a8625c637d89c512e18b2158e43f982a74cfe05e168b60
+  md5: 9cfc0beef98713d3be47f934251b5154
+  size: 1056458
+  timestamp: 1710365909934
+- kind: conda
+  name: libcufile-dev
+  version: 1.9.1.3
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-dev-1.9.1.3-0.tar.bz2
+  sha256: c01420a94058ba58aa19d8dc07e99243ded68b424fd82e73ad0da12ef5a4c037
+  md5: aed936244622103d2ca59a308ff0f421
+  depends:
+  - libcufile >=1.9.1.3
+  size: 14955
+  timestamp: 1710365923835
+- kind: conda
+  name: libcurand
+  version: 10.3.5.147
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.5.147-0.tar.bz2
+  sha256: cb15f89cfb48e735d93b0c96c81b36dd05c9b23f0d0228677016d5042bb6a928
+  md5: e9406bdc4209f8cd5fdb40c8df41d3d9
+  size: 54279240
+  timestamp: 1710543564823
+- kind: conda
+  name: libcurand
+  version: 10.3.5.147
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcurand-10.3.5.147-0.tar.bz2
+  sha256: 039ad35b8cb50bdfbacbad67cbc8496aaa1f9afabf9d2945c77d6bcf5d6d1c0f
+  md5: a28f5f60348a2f498314d47f9c677441
+  size: 3622
+  timestamp: 1710545967557
+- kind: conda
+  name: libcurand-dev
+  version: 10.3.5.147
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-dev-10.3.5.147-0.tar.bz2
+  sha256: 8ab901ab07a45f37cf4a77f2fcc7ae92ec65de386afe9fe512452685e5a0293f
+  md5: 3f0b52f4076c3d8c857664629319f1cf
+  depends:
+  - libcurand >=10.3.5.147
+  size: 460690
+  timestamp: 1710543587166
+- kind: conda
+  name: libcurand-dev
+  version: 10.3.5.147
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcurand-dev-10.3.5.147-0.tar.bz2
+  sha256: be06a8bcadcc30117a0a7d34a9f88f19fd70e6b72addc56069b4f12795e3dd44
+  md5: 5e7299fb7982b3add1ea8580b56e58a5
+  depends:
+  - libcurand >=10.3.5.147
+  size: 52136536
+  timestamp: 1710546052359
+- kind: conda
+  name: libcusolver
+  version: 11.6.1.9
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.6.1.9-0.tar.bz2
+  sha256: 40ca27c4434bd6c5b3731e3fa359808fd31d88a5b6427e7119e19f47c43d5d94
+  md5: 5f4393c1f6f28d1eaaef31fdd5005995
+  size: 119531746
+  timestamp: 1711623954011
+- kind: conda
+  name: libcusolver
+  version: 11.6.1.9
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcusolver-11.6.1.9-0.tar.bz2
+  sha256: 8d9d2991b27e6dd66bf354170c82c0bc47d72887608abfb28bc355255ebac647
+  md5: bbcfa30b8dc8886329358c1559c7a794
+  size: 29805
+  timestamp: 1711630059586
+- kind: conda
+  name: libcusolver-dev
+  version: 11.6.1.9
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-dev-11.6.1.9-0.tar.bz2
+  sha256: 10c13d369a6fa6a9fd5f635f0e3feab8468342809fd32866e5aa5fe64239359d
+  md5: 925d1704fc89a116c60b6ff058916133
+  depends:
+  - libcusolver >=11.6.1.9
+  size: 50331
+  timestamp: 1711623993744
+- kind: conda
+  name: libcusolver-dev
+  version: 11.6.1.9
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcusolver-dev-11.6.1.9-0.tar.bz2
+  sha256: 3d2b4fa24a66e034c0d4148329a0885941a12292459a791c0fd3cde8f839e088
+  md5: d2ea6c1a8abe5a436c9f59a35e45a69f
+  depends:
+  - libcusolver >=11.6.1.9
+  size: 116774002
+  timestamp: 1711630142669
+- kind: conda
+  name: libcusparse
+  version: 12.3.1.170
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-12.3.1.170-0.tar.bz2
+  sha256: 8bc0bb3636feb2e7a20cd47907d7fc6d7a28aea54c4731496f11d2a259b574f2
+  md5: e5d6c740f6a6a6fb28f71cbabef7a613
+  size: 188320273
+  timestamp: 1710544351539
+- kind: conda
+  name: libcusparse
+  version: 12.3.1.170
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcusparse-12.3.1.170-0.tar.bz2
+  sha256: f1f893ea386bd60faefb6f00c381c3ff5d37e1ade5cc76ebcd7ab237a7501ae7
+  md5: 3d3de5146dabaff5a217710fa052a159
+  size: 13077
+  timestamp: 1710546804883
+- kind: conda
+  name: libcusparse-dev
+  version: 12.3.1.170
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-dev-12.3.1.170-0.tar.bz2
+  sha256: 2185a04d01af549a7930199d25fb91995c6c35ec30469ad66f1ceb508f1969d3
+  md5: 3d3f81963e5a36e2b66fa2e5b31cb304
+  depends:
+  - libcusparse >=12.3.1.170
+  size: 186871715
+  timestamp: 1710544411513
+- kind: conda
+  name: libcusparse-dev
+  version: 12.3.1.170
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libcusparse-dev-12.3.1.170-0.tar.bz2
+  sha256: 5b85df69a99e1990254bbbcc5ce1c4ef24820b648bf1009474de367a06248746
+  md5: 6591783b48eac8d587cca3ced3adfe7f
+  depends:
+  - libcusparse >=12.3.1.170
+  size: 184496918
+  timestamp: 1710546892759
+- kind: conda
+  name: libdeflate
+  version: '1.17'
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
+  sha256: f9983a8ea03531f2c14bce76c870ca325c0fddf0c4e872bff1f78bc52624179c
+  md5: 5cc781fd91968b11a8a7fdbee0982676
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 65017
+  timestamp: 1673785897585
+- kind: conda
+  name: libdeflate
+  version: '1.17'
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.17-hcfcfb64_0.conda
+  sha256: 76e642ca8a11da1b537506447f8089353b6607956c069c938a4bec4de36e1194
+  md5: ae9dfb57bcb42093a2417aceabb530f7
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 151946
+  timestamp: 1673786168055
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h7f98852_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58292
+  timestamp: 1636488182923
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h8ffe710_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  md5: 2c96d1b6915b408893f9472569dee135
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 42063
+  timestamp: 1636489106777
+- kind: conda
+  name: libgcc
+  version: 14.1.0
+  build: h77fa898_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
+  sha256: 10fa74b69266a2be7b96db881e18fa62cfa03082b65231e8d652e897c4b335a3
+  md5: 002ef4463dd1e2b44a94a4ace468f5d2
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.1.0 h77fa898_1
+  - libgcc-ng ==14.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 846380
+  timestamp: 1724801836552
+- kind: conda
+  name: libgcc-ng
+  version: 14.1.0
+  build: h69a702a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h69a702a_1.conda
+  sha256: b91f7021e14c3d5c840fbf0dc75370d6e1f7c7ff4482220940eaafb9c64613b7
+  md5: 1efc0ad219877a73ef977af7dbb51f17
+  depends:
+  - libgcc 14.1.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 52170
+  timestamp: 1724801842101
+- kind: conda
+  name: libgfortran
+  version: 14.1.0
+  build: h69a702a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.1.0-h69a702a_1.conda
+  sha256: ed77f04f873e43a26e24d443dd090631eedc7d0ace3141baaefd96a123e47535
+  md5: 591e631bc1ae62c64f2ab4f66178c097
+  depends:
+  - libgfortran5 14.1.0 hc5f4f2c_1
+  constrains:
+  - libgfortran-ng ==14.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 52142
+  timestamp: 1724801872472
+- kind: conda
+  name: libgfortran-ng
+  version: 14.1.0
+  build: h69a702a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_1.conda
+  sha256: a2dc35cb7f87bb5beebf102d4085574c6a740e1df58e743185d4434cc5e4e0ae
+  md5: 16cec94c5992d7f42ae3f9fa8b25df8d
+  depends:
+  - libgfortran 14.1.0 h69a702a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 52212
+  timestamp: 1724802086021
+- kind: conda
+  name: libgfortran5
+  version: 14.1.0
+  build: hc5f4f2c_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
+  sha256: c40d7db760296bf9c776de12597d2f379f30e890b9ae70c1de962ff2aa1999f6
+  md5: 10a0cef64b784d6ab6da50ebca4e984d
+  depends:
+  - libgcc >=14.1.0
+  constrains:
+  - libgfortran 14.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1459939
+  timestamp: 1724801851300
+- kind: conda
+  name: libhwloc
+  version: 2.11.1
+  build: default_h8125262_1000
+  build_number: 1000
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+  sha256: 92728e292640186759d6dddae3334a1bc0b139740b736ffaeccb825fb8c07a2e
+  md5: 933bad6e4658157f1aec9b171374fde2
+  depends:
+  - libxml2 >=2.12.7,<3.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2379689
+  timestamp: 1720461835526
+- kind: conda
+  name: libhwloc
+  version: 2.11.1
+  build: default_hecaa2ac_1000
+  build_number: 1000
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.1-default_hecaa2ac_1000.conda
+  sha256: 8473a300e10b79557ce0ac81602506b47146aff3df4cc3568147a7dd07f480a2
+  md5: f54aeebefb5c5ff84eca4fb05ca8aa3a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2417964
+  timestamp: 1720460562447
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hcfcfb64_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
+  sha256: 5f844dd19b046d43174ad80c6ea75b5d504020e3b63cfbc4ace97b8730d35c7b
+  md5: e1eb10b1cca179f2baa3601e4efc8712
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-only
+  purls: []
+  size: 636146
+  timestamp: 1702682547199
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hd590300_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
+  sha256: 8ac2f6a9f186e76539439e50505d98581472fedb347a20e7d1f36429849f05c9
+  md5: d66573916ffcf376178462f1b61c941e
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  purls: []
+  size: 705775
+  timestamp: 1702682170569
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 21_linux64_mkl
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-21_linux64_mkl.conda
+  sha256: 47408adf63bd831bbe1596e6571278e412793dd07182e4247ee548744b2abf9e
+  md5: 52837ab7fd5b43d3960c62e5c91958d6
+  depends:
+  - libblas 3.9.0 21_linux64_mkl
+  constrains:
+  - libcblas 3.9.0 21_linux64_mkl
+  - liblapacke 3.9.0 21_linux64_mkl
+  - blas * mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14550
+  timestamp: 1705979612063
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 5_hd5c7e75_netlib
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-5_hd5c7e75_netlib.tar.bz2
+  sha256: b60ac4f2f367126ae56bfb887ff70a2b202b30597ada35506b13691c76c844e0
+  md5: 5cd729d515884d1302f78010c4bf8748
+  depends:
+  - libblas 3.9.0.*
+  - m2w64-gcc-libs
+  track_features:
+  - blas_netlib
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2878872
+  timestamp: 1618013145083
+- kind: conda
+  name: liblapacke
+  version: 3.9.0
+  build: 21_linux64_mkl
+  build_number: 21
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-21_linux64_mkl.conda
+  sha256: 15486eece0c448ef3765d7f7d485257125808f0007bda2553c685b53cffe107f
+  md5: 0d45f03de7143f324b37454af46feb26
+  depends:
+  - libblas 3.9.0 21_linux64_mkl
+  - libcblas 3.9.0 21_linux64_mkl
+  - liblapack 3.9.0 21_linux64_mkl
+  constrains:
+  - blas * mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14547
+  timestamp: 1705979627914
+- kind: conda
+  name: libnpp
+  version: 12.2.5.30
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-12.2.5.30-0.tar.bz2
+  sha256: fbad0c1fb5737312c780d65816512d4e84b87c1a782aab90d01b250305af3891
+  md5: 528dd173d5883e27ecd3cb1e25f6ec03
+  size: 149716917
+  timestamp: 1710543759259
+- kind: conda
+  name: libnpp
+  version: 12.2.5.30
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libnpp-12.2.5.30-0.tar.bz2
+  sha256: 0e5799c28b9d3a7486c205431785dcccde09342a03b595875550eab3908dfdb3
+  md5: ef1bbea5b348039d82d18604b2deefdf
+  size: 317786
+  timestamp: 1710548580563
+- kind: conda
+  name: libnpp-dev
+  version: 12.2.5.30
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-dev-12.2.5.30-0.tar.bz2
+  sha256: 520f440de00aadcc66e00eacf5814854685ce0d68cbcf51222e3aab0c5d5fe92
+  md5: fc0ff7966b2fc067b8ae0b101c75836f
+  depends:
+  - libnpp >=12.2.5.30
+  size: 551586
+  timestamp: 1710543810642
+- kind: conda
+  name: libnpp-dev
+  version: 12.2.5.30
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libnpp-dev-12.2.5.30-0.tar.bz2
+  sha256: 4bf0b9448cbeba4ed4f2b67b0ae31dcc337f77e076d8af06301dba0dd4a974f5
+  md5: af51f6595654ae6b575cb5685a1dd9f4
+  depends:
+  - libnpp >=12.2.5.30
+  size: 145964412
+  timestamp: 1710548706373
+- kind: conda
+  name: libnsl
+  version: 2.0.1
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 33408
+  timestamp: 1697359010159
+- kind: conda
+  name: libnvjpeg
+  version: 12.3.1.117
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-12.3.1.117-0.tar.bz2
+  sha256: ae7a9caa5f4b8391eccdf58475f19c34f99072678ecac071470eccd0d837482f
+  md5: a74e60028f611186ca17095d2d5074d1
+  size: 3107405
+  timestamp: 1710543206669
+- kind: conda
+  name: libnvjpeg
+  version: 12.3.1.117
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-12.3.1.117-0.tar.bz2
+  sha256: a0d59a353c24a7b94fe5f1fb45087d1d8c905b6045e318176d40dc8847e961a8
+  md5: 3cc2be851bf0a74a00b62ba91651a3f0
+  size: 5050
+  timestamp: 1710545702272
+- kind: conda
+  name: libnvjpeg-dev
+  version: 12.3.1.117
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
+  sha256: e2159fb7804c1d7c75f8fc8923023de175e45e1cf3c46ea7a4add14079c21878
+  md5: c3bef7506f27273e0d4c0ff87ff84628
+  depends:
+  - libnvjpeg >=12.3.1.117
+  size: 13464
+  timestamp: 1710543208085
+- kind: conda
+  name: libnvjpeg-dev
+  version: 12.3.1.117
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/libnvjpeg-dev-12.3.1.117-0.tar.bz2
+  sha256: 89cd948aeb10758a72cc763df14a9cafc2b6bae1f87562bdfc97376dd563eb19
+  md5: 49fe5ba7019892aee92531981864066b
+  depends:
+  - libnvjpeg >=12.3.1.117
+  size: 2621000
+  timestamp: 1710545783617
+- kind: conda
+  name: libpng
+  version: 1.6.43
+  build: h19919ed_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+  sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
+  md5: 77e398acc32617a0384553aea29e866b
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  purls: []
+  size: 347514
+  timestamp: 1708780763195
+- kind: conda
+  name: libpng
+  version: 1.6.43
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+  sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
+  md5: 009981dd9cfcaa4dbfa25ffaed86bcae
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 288221
+  timestamp: 1708780443939
+- kind: conda
+  name: libsqlite
+  version: 3.46.0
+  build: hde9e2c9_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
+  md5: 18aa975d2094c34aef978060ae7da7d8
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 865346
+  timestamp: 1718050628718
+- kind: conda
+  name: libsqlite
+  version: 3.46.1
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
+  sha256: ef83f90961630bc54a95e48062b05cf9c9173a822ea01784288029613a45eea4
+  md5: 8a7c1ad01f58623bfbae8d601db7cf3b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  purls: []
+  size: 876666
+  timestamp: 1725354171439
+- kind: conda
+  name: libstdcxx
+  version: 14.1.0
+  build: hc0a3c3a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
+  sha256: 44decb3d23abacf1c6dd59f3c152a7101b7ca565b4ef8872804ceaedcc53a9cd
+  md5: 9dbb9699ea467983ba8a4ba89b08b066
+  depends:
+  - libgcc 14.1.0 h77fa898_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3892781
+  timestamp: 1724801863728
+- kind: conda
+  name: libstdcxx-ng
+  version: 14.1.0
+  build: h4852527_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-h4852527_1.conda
+  sha256: a2dc44f97290740cc187bfe94ce543e6eb3c2ea8964d99f189a1d8c97b419b8c
+  md5: bd2598399a70bb86d8218e95548d735e
+  depends:
+  - libstdcxx 14.1.0 hc0a3c3a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 52219
+  timestamp: 1724801897766
+- kind: conda
+  name: libtiff
+  version: 4.5.0
+  build: h6adf6a1_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
+  sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
+  md5: 2e648a34072eb39d7c4fc2a9981c5f0c
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  purls: []
+  size: 406655
+  timestamp: 1673817946777
+- kind: conda
+  name: libtiff
+  version: 4.5.0
+  build: hf8721a0_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.0-hf8721a0_2.conda
+  sha256: 86cf8066db11f84b506ba246944901584ab199dfe7490586f5e9b6c299e3b8e0
+  md5: 2e003e276cc1375192569c96afd3d984
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.17,<1.18.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: HPND
+  purls: []
+  size: 1156984
+  timestamp: 1673818439563
+- kind: conda
+  name: libuuid
+  version: 2.38.1
+  build: h0b41bf4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 33601
+  timestamp: 1680112270483
+- kind: conda
+  name: libuv
+  version: 1.48.0
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
+  sha256: 6151c51857c2407139ce22fdc956022353e675b2bc96991a9201d51cceaa90b4
+  md5: 485e49e1d500d996844df14cabf64d73
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 289753
+  timestamp: 1709913743184
+- kind: conda
+  name: libwebp-base
+  version: 1.4.0
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 274359
+  timestamp: 1713200524021
+- kind: conda
+  name: libwebp-base
+  version: 1.4.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 438953
+  timestamp: 1713199854503
+- kind: conda
+  name: libxcb
+  version: '1.13'
+  build: h7f98852_1004
+  build_number: 1004
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+  sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+  md5: b3653fdc58d03face9724f602218a904
+  depends:
+  - libgcc-ng >=9.4.0
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 399895
+  timestamp: 1636658924671
+- kind: conda
+  name: libxcb
+  version: '1.13'
+  build: hcd874cb_1004
+  build_number: 1004
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.13-hcd874cb_1004.tar.bz2
+  sha256: a6fe7468ed3b9898f7beaa75f7e3adff9c7b96b39a36a3f8399c37223ec6a9e8
+  md5: a6d7fd030532378ecb6ba435cd9f8234
+  depends:
+  - m2w64-gcc-libs
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1340194
+  timestamp: 1636659621965
+- kind: conda
+  name: libxcrypt
+  version: 4.4.36
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 100393
+  timestamp: 1702724383534
+- kind: conda
+  name: libxml2
+  version: 2.12.7
+  build: h0f24e4e_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+  sha256: ae78197961b09b0eef4ee194a44e4adc4555c0f2f20c348086b0cd8aaf2f7731
+  md5: ed4d301f0d2149b34deb9c4fecafd836
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1682090
+  timestamp: 1721031296951
+- kind: conda
+  name: libxml2
+  version: 2.12.7
+  build: hc051c1a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-hc051c1a_1.conda
+  sha256: 576ea9134176636283ff052897bf7a91ffd8ac35b2c505dfde2890ec52849698
+  md5: 340278ded8b0dc3a73f3660bbb0adbc6
+  depends:
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 704984
+  timestamp: 1717546454837
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: h4ab18f5_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h4ab18f5_6.conda
+  sha256: 8ced4afed6322172182af503f21725d072a589a6eb918f8a58135c1e00d35980
+  md5: 27329162c0dc732bcf67a4e0cd488125
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_6
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 61571
+  timestamp: 1716874066944
+- kind: conda
+  name: libzlib
+  version: 1.3.1
+  build: h2466b09_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+  sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
+  md5: d4483ca8afc57ddf1f6dded53b36c17f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 56186
+  timestamp: 1716874730539
+- kind: conda
+  name: llvm-openmp
+  version: 18.1.7
+  build: ha31de31_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-18.1.7-ha31de31_0.conda
+  sha256: 142caccdaf4cabfeb589e408c72e0e7e85ba4ae6c0d0ab5417c2a7db6f1da5a5
+  md5: 7234f31acd176e402e91e03feba90f7d
+  depends:
+  - libzlib >=1.2.13,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - openmp 18.1.7|18.1.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 58663081
+  timestamp: 1717851544397
+- kind: conda
+  name: m2w64-gcc-libgfortran
+  version: 5.3.0
+  build: '6'
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  md5: 066552ac6b907ec6d72c0ddab29050dc
+  depends:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  license: GPL, LGPL, FDL, custom
+  purls: []
+  size: 350687
+  timestamp: 1608163451316
+- kind: conda
+  name: m2w64-gcc-libs
+  version: 5.3.0
+  build: '7'
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  md5: fe759119b8b3bfa720b8762c6fdc35de
+  depends:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  purls: []
+  size: 532390
+  timestamp: 1608163512830
+- kind: conda
+  name: m2w64-gcc-libs-core
+  version: 5.3.0
+  build: '7'
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+  depends:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  purls: []
+  size: 219240
+  timestamp: 1608163481341
+- kind: conda
+  name: m2w64-gmp
+  version: 6.1.0
+  build: '2'
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  md5: 53a1c73e1e3d185516d7e3af177596d9
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: LGPL3
+  purls: []
+  size: 743501
+  timestamp: 1608163782057
+- kind: conda
+  name: m2w64-libwinpthread-git
+  version: 5.0.0.4634.697f757
+  build: '2'
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  md5: 774130a326dee16f1ceb05cc687ee4f0
+  depends:
+  - msys2-conda-epoch ==20160418
+  license: MIT, BSD
+  purls: []
+  size: 31928
+  timestamp: 1608166099896
+- kind: conda
+  name: mkl
+  version: 2024.0.0
+  build: h66d3029_49658
+  build_number: 49658
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49658.conda
+  sha256: 7df43df56b68908c266232d025b4734d12de41f636b8158283c43e40611165e4
+  md5: 9782703dbc6e14cbc32bc89ec76922c2
+  depends:
+  - intel-openmp 2024.*
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  purls: []
+  size: 108374598
+  timestamp: 1706183251746
+- kind: conda
+  name: mkl
+  version: 2024.0.0
+  build: ha957f24_49657
+  build_number: 49657
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.0.0-ha957f24_49657.conda
+  sha256: bdda7219d19c2963f7c43c806e2c2f2009e3ccb1963f74dcf1176b632f71c8d6
+  md5: 21acbdcbba8d049c8617c486bdc9bc84
+  depends:
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - llvm-openmp >=17.0.6
+  - tbb 2021.*
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  purls: []
+  size: 126089019
+  timestamp: 1706182192110
+- kind: conda
+  name: mkl-devel
+  version: 2024.0.0
+  build: ha770c72_49657
+  build_number: 49657
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2024.0.0-ha770c72_49657.conda
+  sha256: e2eb895f16b20fec21c87bb515da7da91edcd21642ef3f26f087ac05c8cd83fa
+  md5: ebf3120c4461be611e9c3fdebfe64b1e
+  depends:
+  - mkl 2024.0.0 ha957f24_49657
+  - mkl-include 2024.0.0 ha957f24_49657
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  purls: []
+  size: 31629
+  timestamp: 1706182857218
+- kind: conda
+  name: mkl-include
+  version: 2024.0.0
+  build: ha957f24_49657
+  build_number: 49657
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2024.0.0-ha957f24_49657.conda
+  sha256: 4a9474908407578934f2edcb112a033f4893b35c6f129869532d5140fbc68601
+  md5: 9eaab03e8286b2c74d0d73ae14fb1709
+  license: LicenseRef-ProprietaryIntel
+  license_family: Proprietary
+  purls: []
+  size: 768086
+  timestamp: 1706182478041
+- kind: conda
+  name: msys2-conda-epoch
+  version: '20160418'
+  build: '1'
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  md5: b0309b72560df66f71a9d5e34a5efdfa
+  purls: []
+  size: 3227
+  timestamp: 1608166968312
+- kind: conda
+  name: ncurses
+  version: '6.5'
+  build: he02047a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 889086
+  timestamp: 1724658547447
+- kind: conda
+  name: nettle
+  version: '3.6'
+  build: he412f7d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
+  sha256: d929f0c53f2bb74c8e3d97dc1c53cc76b7cec97837fcf87998fa3dd447f03b36
+  md5: f050099af540c1c960c813b06bca89ad
+  depends:
+  - libgcc-ng >=7.5.0
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  purls: []
+  size: 6773272
+  timestamp: 1605211080998
+- kind: conda
+  name: nsight-compute
+  version: 2024.1.1.4
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/nsight-compute-2024.1.1.4-0.tar.bz2
+  sha256: 33935f28b007d3d5f584abd22485251ad7eea91b4b9f11c960a053fdd7be8a48
+  md5: 217ed2ff255f52cbef787aba3f9b9637
+  size: 699526661
+  timestamp: 1709778043113
+- kind: conda
+  name: nsight-compute
+  version: 2024.1.1.4
+  build: '0'
+  subdir: win-64
+  url: https://conda.anaconda.org/nvidia/win-64/nsight-compute-2024.1.1.4-0.tar.bz2
+  sha256: 4c8b1724a13531fb2d745ab573413b3f230cadb598eba2aa777f2170a0dfe87a
+  md5: 4d0a3cbc76e36b490c04ae6e4115262d
+  size: 535698663
+  timestamp: 1709779654696
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py39h474f0d3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
+  sha256: fa792c330e1d18854e4ca1ea8bf90ffae6787c133ebdc331f1ba6f565d28b599
+  md5: aa265f5697237aa13cc10f53fa8acc4f
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 7039431
+  timestamp: 1707225726227
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py39hddb5d58_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py39hddb5d58_0.conda
+  sha256: 25473fb10de8e3d92ea07777fce90508b5fce76fd942b333625ae27f7c50d74d
+  md5: 6e30ff8f2d3f59f45347dfba8bc22a04
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/numpy?source=hash-mapping
+  size: 5920615
+  timestamp: 1707226471242
+- kind: conda
+  name: openh264
+  version: 2.1.1
+  build: h780b84a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+  sha256: 2ce3df1edb23541595443c7697e5568ae6426fa4d365dede45b16b0310bd6a06
+  md5: 034a6f90f1bbc7ba11d04b84ec9d74c8
+  depends:
+  - libgcc-ng >=9.3.0
+  - libstdcxx-ng >=9.3.0
+  - zlib >=1.2.11,<1.3.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 1585354
+  timestamp: 1609583081716
+- kind: conda
+  name: openjpeg
+  version: 2.5.0
+  build: ha2aaf27_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-ha2aaf27_2.conda
+  sha256: 1fb72db47e9b1cdb4980a1fd031e31fad2c6a4a632fc602e7d6fa74f4f491608
+  md5: db0490689232e8e38c312281df6f31a2
+  depends:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 237111
+  timestamp: 1671435754860
+- kind: conda
+  name: openjpeg
+  version: 2.5.0
+  build: hfec8fc6_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
+  sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
+  md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 352022
+  timestamp: 1671435172657
+- kind: conda
+  name: openssl
+  version: 3.3.2
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+  sha256: a45c42f3577294e22ac39ddb6ef5a64fd5322e8a6725afefbf4f2b4109340bf9
+  md5: 1dc86753693df5e3326bb8a85b74c589
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 8396053
+  timestamp: 1725412961673
+- kind: conda
+  name: openssl
+  version: 3.3.2
+  build: hb9d3cd8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+  sha256: cee91036686419f6dd6086902acf7142b4916e1c4ba042e9ca23e151da012b6d
+  md5: 4d638782050ab6faa27275bed57e9b4e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 2891789
+  timestamp: 1725410790053
+- kind: conda
+  name: pillow
+  version: 9.4.0
+  build: py39h2320bf1_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda
+  sha256: 77348588ae7cc8034b63e8a71b6695ba22761e1c531678e724cf06a12be3d1e2
+  md5: d2f79132b9c8e416058a4cd84ef27b3d
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.14,<3.0a0
+  - libgcc-ng >=12
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - tk >=8.6.12,<8.7.0a0
+  license: LicenseRef-PIL
+  purls:
+  - pkg:pypi/pillow?source=hash-mapping
+  size: 46203066
+  timestamp: 1675487301925
+- kind: conda
+  name: pillow
+  version: 9.4.0
+  build: py39hcebd2be_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-9.4.0-py39hcebd2be_1.conda
+  sha256: 518c9cd2e83494858f96cc1a522d97e9d01d0465393f4e75ee0f3eae9c5bb936
+  md5: 7cf5bb13bc3823aa5159e00c7d1cb18f
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - jpeg >=9e,<10a
+  - lcms2 >=2.14,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - tk >=8.6.12,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LicenseRef-PIL
+  purls:
+  - pkg:pypi/pillow?source=hash-mapping
+  size: 45881018
+  timestamp: 1675487749708
+- kind: conda
+  name: pip
+  version: '24.2'
+  build: pyh8b19718_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.2-pyh8b19718_1.conda
+  sha256: d820e5358bcb117fa6286e55d4550c60b0332443df62121df839eab2d11c890b
+  md5: 6c78fbb8ddfd64bcb55b5cbafd2d2c43
+  depends:
+  - python >=3.8,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=hash-mapping
+  size: 1237976
+  timestamp: 1724954490262
+- kind: conda
+  name: portalocker
+  version: 2.10.1
+  build: py39hcbf5309_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/portalocker-2.10.1-py39hcbf5309_0.conda
+  sha256: f1201cd2dce0b0618c2087f2e703d9345c7fec28493c1f56b1393e97bfa8fd47
+  md5: 32eefc9a1eea474ad26d6c03910ab2a0
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - pywin32
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 38125
+  timestamp: 1720928838336
+- kind: conda
+  name: portalocker
+  version: 2.10.1
+  build: py39hf3d152e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/portalocker-2.10.1-py39hf3d152e_0.conda
+  sha256: a5b79f86619c5a92401436c4f0b0e20cf04642fffd5a55fb3a1d439d60d15283
+  md5: 514d9f161bc6efe6ad00cce8ccda1a04
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 37578
+  timestamp: 1720928656416
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: h36c2ea0_1001
+  build_number: 1001
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 5625
+  timestamp: 1606147468727
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: hcd874cb_1001
+  build_number: 1001
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  md5: a1f820480193ea83582b13249a7e7bd9
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 6417
+  timestamp: 1606147814351
+- kind: conda
+  name: pthreads-win32
+  version: 2.9.1
+  build: hfa6e2cd_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+  sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
+  md5: e2da8758d7d51ff6aa78a14dfb9dbed4
+  depends:
+  - vc 14.*
+  license: LGPL 2
+  purls: []
+  size: 144301
+  timestamp: 1537755684331
+- kind: conda
+  name: pycparser
+  version: '2.22'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+  sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
+  md5: 844d9eb3b43095b031874477f7d70088
+  depends:
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pycparser?source=hash-mapping
+  size: 105098
+  timestamp: 1711811634025
+- kind: conda
+  name: pysocks
+  version: 1.7.1
+  build: pyh0701188_6
+  build_number: 6
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
+  sha256: b3a612bc887f3dd0fb7c4199ad8e342bd148cf69a9b74fd9468a18cf2bef07b7
+  md5: 56cd9fe388baac0e90c7149cfac95b60
+  depends:
+  - __win
+  - python >=3.8
+  - win_inet_pton
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pysocks?source=hash-mapping
+  size: 19348
+  timestamp: 1661605138291
+- kind: conda
+  name: pysocks
+  version: 1.7.1
+  build: pyha2e5f31_6
+  build_number: 6
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pysocks?source=hash-mapping
+  size: 18981
+  timestamp: 1661604969727
+- kind: conda
+  name: python
+  version: 3.9.19
+  build: h0755675_0_cpython
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.19-h0755675_0_cpython.conda
+  sha256: b9253ca9ca5427e6da4b1d43353a110e0f2edfab9c951afb4bf01cbae2825b31
+  md5: d9ee3647fbd9e8595b8df759b2bbefb8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.45.2,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  purls: []
+  size: 23800555
+  timestamp: 1710940120866
+- kind: conda
+  name: python
+  version: 3.9.19
+  build: h4de0772_0_cpython
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.9.19-h4de0772_0_cpython.conda
+  sha256: 92d847bc9e79a60c1d139aa4ca0385d283b90aa2d7421bb3ffcb5dc0678fd72f
+  md5: b6999bc275e0e6beae7b1c8ea0be1e85
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - vc >=14.1,<15
+  - vc14_runtime >=14.16.27033
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  purls: []
+  size: 16906240
+  timestamp: 1710938565297
+- kind: conda
+  name: python_abi
+  version: '3.9'
+  build: 5_cp39
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-5_cp39.conda
+  sha256: 019e2f8bca1d1f1365fbb9965cd95bb395c92c89ddd03165db82f5ae89a20812
+  md5: 40363a30db350596b5f225d0d5a33328
+  constrains:
+  - python 3.9.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6193
+  timestamp: 1723823354399
+- kind: conda
+  name: python_abi
+  version: '3.9'
+  build: 5_cp39
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.9-5_cp39.conda
+  sha256: ee9471759ba567d5a4922d4fae95f58a0070db7616cba72e3bfb22cd5c50e37a
+  md5: 86ba1bbcf9b259d1592201f3c345c810
+  constrains:
+  - python 3.9.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6706
+  timestamp: 1723823197703
+- kind: conda
+  name: pytorch
+  version: 1.13.1
+  build: py3.9_cuda11.6_cudnn8.3.2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-1.13.1-py3.9_cuda11.6_cudnn8.3.2_0.tar.bz2
+  sha256: c75ef42a7f8f0222ed899a99655d0d4d09b86537d3b583611c8512d63ed7a546
+  md5: 7744012fbef5c7eccfb364f59a6ae297
+  depends:
+  - blas * mkl
+  - mkl >=2018
+  - python >=3.9,<3.10.0a0
+  - pytorch-cuda >=11.6,<11.7
+  - pytorch-mutex 1.0 cuda
+  - typing_extensions
+  constrains:
+  - cpuonly <0
+  license: BSD 3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch?source=hash-mapping
+  size: 1366815433
+  timestamp: 1670533933725
+- kind: conda
+  name: pytorch
+  version: 1.13.1
+  build: py3.9_cuda11.6_cudnn8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/pytorch/win-64/pytorch-1.13.1-py3.9_cuda11.6_cudnn8_0.tar.bz2
+  sha256: 921a8dc3a992d9c10ae71314ec70683dbfd45ff5ef28af2205d2caeadc64163e
+  md5: 289ffbae7354c49e6afa983a145c0b1a
+  depends:
+  - blas * mkl
+  - intel-openmp
+  - libuv >=1.40.0,<2.0a0
+  - mkl >=2018
+  - python >=3.9,<3.10.0a0
+  - pytorch-cuda >=11.6,<11.7
+  - pytorch-mutex 1.0 cuda
+  - typing_extensions
+  constrains:
+  - cpuonly <0
+  license: BSD 3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch?source=hash-mapping
+  size: 1320595448
+  timestamp: 1670534271830
+- kind: conda
+  name: pytorch-cuda
+  version: '11.6'
+  build: h867d48c_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/pytorch/noarch/pytorch-cuda-11.6-h867d48c_0.tar.bz2
+  sha256: 213c64318b94f93077de746d9c6936dd5bafe687a95212624167282b65574760
+  md5: 9a9b208f1b5fb5ffa3670fd04c5adfe9
+  depends:
+  - cuda 11.6.*
+  constrains:
+  - cuda-nvprune >=11.6,<11.7
+  - cuda-nvcc >=11.6,<11.7
+  - cuda-nvtx >=11.6,<11.7
+  - cuda-cupti >=11.6,<11.7
+  - cuda-tools >=11.6,<11.7
+  - cuda-nvml-dev >=11.6,<11.7
+  - cuda-cudart-dev >=11.6,<11.7
+  - cuda-toolkit >=11.6,<11.7
+  - cuda-libraries >=11.6,<11.7
+  - cuda-driver-dev >=11.6,<11.7
+  - cuda-cudaart-dev >=11.6,<11.7
+  - cuda-command-line-tools >=11.6,<11.7
+  - cuda-compiler >=11.6,<11.7
+  - cuda-libraries-dev >=11.6,<11.7
+  - cuda-cuobjdump >=11.6,<11.7
+  - cuda-runtime >=11.6,<11.7
+  - cuda-nvrtc >=11.6,<11.7
+  - cuda-cccl >=11.6,<11.7
+  - cuda-cuxxfilt >=11.6,<11.7
+  - cuda-cudart >=11.6,<11.7
+  - cuda-nvrtc-dev >=11.6,<11.7
+  purls: []
+  size: 3056
+  timestamp: 1660092164201
+- kind: conda
+  name: pytorch-mutex
+  version: '1.0'
+  build: cuda
+  build_number: 100
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+  sha256: c16316183f51b74ca5eee4dcb8631052f328c0bbf244176734a0b7d390b81ee3
+  md5: a948316e36fb5b11223b3fcfa93f8358
+  purls: []
+  size: 2906
+  timestamp: 1628062930777
+- kind: conda
+  name: pywin32
+  version: '306'
+  build: py39h99910a6_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py39h99910a6_2.conda
+  sha256: bae89555b73c8bbbb9efe88490f2d16c010188dd078ed3aa39c2ba3084e31608
+  md5: eab91442160b49994dd2e224e6082770
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/pywin32?source=hash-mapping
+  size: 5808124
+  timestamp: 1695974471118
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py39h8cd3c5a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py39h8cd3c5a_1.conda
+  sha256: e07299422b0197eba5ceeef4fa76d4ee742a7f0cafcba97b91498b9764e7d990
+  md5: 76e82e62b7bda86a7fceb1f32585abad
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 181692
+  timestamp: 1725456337437
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py39ha55e580_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py39ha55e580_1.conda
+  sha256: 36ec720da777235b0775119af4d9ebbb821bb71a6c6b32b6bd4c4f6be9d895ff
+  md5: 099b4a8943b67a0a35695fa4275c0292
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 157276
+  timestamp: 1725456761667
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h8228510_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 281456
+  timestamp: 1679532220005
+- kind: conda
+  name: requests
+  version: 2.32.3
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  md5: 5ede4753180c7a550a443c430dc8ab52
+  depends:
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - python >=3.8
+  - urllib3 >=1.21.1,<3
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/requests?source=hash-mapping
+  size: 58810
+  timestamp: 1717057174842
+- kind: conda
+  name: setuptools
+  version: 73.0.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
+  sha256: c9f5e110e3fe5a7c4cd5b9da445c05a1fae000b43ab3a97cb6a501f4267515fc
+  md5: f0b618d7673d1b2464f600b34d912f6f
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=hash-mapping
+  size: 1460460
+  timestamp: 1725348602179
+- kind: conda
+  name: tabulate
+  version: 0.9.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
+  sha256: f6e4a0dd24ba060a4af69ca79d32361a6678e61d78c73eb5e357909b025b4620
+  md5: 4759805cce2d914c38472f70bf4d8bcb
+  depends:
+  - python >=3.7
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tabulate?source=hash-mapping
+  size: 35912
+  timestamp: 1665138565317
+- kind: conda
+  name: tbb
+  version: 2021.12.0
+  build: h84d6215_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.12.0-h84d6215_4.conda
+  sha256: a079dcf42804a841ac2b63784f42e0d2e93401833d4a7d44ddf05b767794d578
+  md5: 1fa72fdeb88f538018612ce2ed9fc789
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc
+  - libgcc-ng >=13
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - libstdcxx
+  - libstdcxx-ng >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 186953
+  timestamp: 1724905442040
+- kind: conda
+  name: tbb
+  version: 2021.12.0
+  build: hc790b64_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_4.conda
+  sha256: d23e589311be6aeacbfb8371bd65d8637c5acc83a149baccc57d2621644fe158
+  md5: bce92c19a6cb64b47866b7271363f747
+  depends:
+  - libhwloc >=2.11.1,<2.11.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 161921
+  timestamp: 1724906383699
+- kind: conda
+  name: termcolor
+  version: 2.4.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/termcolor-2.4.0-pyhd8ed1ab_0.conda
+  sha256: 59588d41f2c02d599fd6528583013d85bd47d17b1acec11edbb29deadd81fbca
+  md5: a5033708ad9283907c3b1bc1f90d0d0d
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/termcolor?source=hash-mapping
+  size: 12721
+  timestamp: 1704358124294
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: h5226925_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  md5: fc048363eb8f03cd1737600a5d08aafe
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3503410
+  timestamp: 1699202577803
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: noxft_h4845f30_101
+  build_number: 101
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3318875
+  timestamp: 1699202167581
+- kind: conda
+  name: torchvision
+  version: 0.14.1
+  build: py39_cu116
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/torchvision-0.14.1-py39_cu116.tar.bz2
+  sha256: 99c1b0146ee888d555e8b2bf02f7babeef9a5cf413e913c833dbb332772991c7
+  md5: 9c0615285900127d8f2194ba63a8b4dd
+  depends:
+  - ffmpeg >=4.2
+  - jpeg
+  - libpng
+  - numpy >=1.11
+  - pillow >=5.3.0,!=8.3.*
+  - python >=3.9,<3.10.0a0
+  - pytorch 1.13.1
+  - pytorch-cuda 11.6.*
+  - pytorch-mutex 1.0 cuda
+  - requests
+  constrains:
+  - cpuonly <0
+  license: BSD
+  purls:
+  - pkg:pypi/torchvision?source=hash-mapping
+  size: 7958818
+  timestamp: 1670555035179
+- kind: conda
+  name: torchvision
+  version: 0.14.1
+  build: py39_cu116
+  subdir: win-64
+  url: https://conda.anaconda.org/pytorch/win-64/torchvision-0.14.1-py39_cu116.tar.bz2
+  sha256: ca45d5227a9539c0ee3f5bb572b5f9fc293f941d11058d3f1b52266921b7d0b4
+  md5: 10f700e260d8e7ea5dbd39718bb4e461
+  depends:
+  - jpeg
+  - libpng
+  - numpy >=1.11
+  - pillow >=5.3.0,!=8.3.*
+  - python >=3.9,<3.10.0a0
+  - pytorch 1.13.1
+  - pytorch-cuda 11.6.*
+  - pytorch-mutex 1.0 cuda
+  - requests
+  constrains:
+  - cpuonly <0
+  license: BSD
+  purls:
+  - pkg:pypi/torchvision?source=hash-mapping
+  size: 7834301
+  timestamp: 1670555591901
+- kind: conda
+  name: tqdm
+  version: 4.66.5
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
+  sha256: f2384902cef72048b0e9bad5c03d7a843de02ba6bc8618a9ecab6ff81a131312
+  md5: c6e94fc2b2ec71ea33fe7c7da259acb4
+  depends:
+  - colorama
+  - python >=3.7
+  license: MPL-2.0 or MIT
+  purls:
+  - pkg:pypi/tqdm?source=hash-mapping
+  size: 89519
+  timestamp: 1722737568509
+- kind: conda
+  name: typing_extensions
+  version: 4.12.2
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
+  depends:
+  - python >=3.8
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  size: 39888
+  timestamp: 1717802653893
+- kind: conda
+  name: tzdata
+  version: 2024a
+  build: h8827d51_1
+  build_number: 1
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
+  sha256: 7d21c95f61319dba9209ca17d1935e6128af4235a67ee4e57a00908a1450081e
+  md5: 8bfdead4e0fff0383ae4c9c50d0531bd
+  license: LicenseRef-Public-Domain
+  purls: []
+  size: 124164
+  timestamp: 1724736371498
+- kind: conda
+  name: ucrt
+  version: 10.0.22621.0
+  build: h57928b3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  md5: 72608f6cd3e5898229c3ea16deb1ac43
+  constrains:
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-Proprietary
+  license_family: PROPRIETARY
+  purls: []
+  size: 1283972
+  timestamp: 1666630199266
+- kind: conda
+  name: urllib3
+  version: 2.2.2
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+  sha256: 00c47c602c03137e7396f904eccede8cc64cc6bad63ce1fc355125df8882a748
+  md5: e804c43f58255e977093a2298e442bb8
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.8
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/urllib3?source=hash-mapping
+  size: 95048
+  timestamp: 1719391384778
+- kind: conda
+  name: vc
+  version: '14.3'
+  build: h8a93ad2_20
+  build_number: 20
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
+  sha256: 23ac5feb15a9adf3ab2b8c4dcd63650f8b7ae860c5ceb073e49cf71d203eddef
+  md5: 8558f367e1d7700554f7cdb823c46faf
+  depends:
+  - vc14_runtime >=14.40.33810
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 17391
+  timestamp: 1717709040616
+- kind: conda
+  name: vc14_runtime
+  version: 14.40.33810
+  build: hcc2c482_20
+  build_number: 20
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_20.conda
+  sha256: bba8daa6f78b26b48fb7e1377eb52160e25495710bf53146c5f405bd50565982
+  md5: ad33c7cd933d69b9dee0f48317cdf137
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.40.33810.* *_20
+  license: LicenseRef-ProprietaryMicrosoft
+  license_family: Proprietary
+  purls: []
+  size: 751028
+  timestamp: 1724712684919
+- kind: conda
+  name: vs2015_runtime
+  version: 14.40.33810
+  build: h3bf8584_20
+  build_number: 20
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+  sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
+  md5: c21f1b4a3a30bbc3ef35a50957578e0e
+  depends:
+  - vc14_runtime >=14.40.33810
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 17395
+  timestamp: 1717709043353
+- kind: conda
+  name: wheel
+  version: 0.44.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.44.0-pyhd8ed1ab_0.conda
+  sha256: d828764736babb4322b8102094de38074dedfc71f5ff405c9dfee89191c14ebc
+  md5: d44e3b085abcaef02983c6305b84b584
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/wheel?source=hash-mapping
+  size: 58585
+  timestamp: 1722797131787
+- kind: conda
+  name: win_inet_pton
+  version: 1.1.0
+  build: pyhd8ed1ab_6
+  build_number: 6
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
+  sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
+  md5: 30878ecc4bd36e8deeea1e3c151b2e0b
+  depends:
+  - __win
+  - python >=3.6
+  license: PUBLIC-DOMAIN
+  purls:
+  - pkg:pypi/win-inet-pton?source=hash-mapping
+  size: 8191
+  timestamp: 1667051294134
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: hcd874cb_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  md5: c46ba8712093cb0114404ae8a7582e1a
+  depends:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 51297
+  timestamp: 1684638355740
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 14468
+  timestamp: 1684637984591
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: h7f98852_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
+  - libgcc-ng >=9.3.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 19126
+  timestamp: 1610071769228
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: hcd874cb_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+  depends:
+  - m2w64-gcc-libs
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 67908
+  timestamp: 1610072296570
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1 and GPL-2.0
+  purls: []
+  size: 418368
+  timestamp: 1660346797927
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h8d14728_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+  md5: 515d77642eaa3639413c6b1bc3f94219
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: LGPL-2.1 and GPL-2.0
+  purls: []
+  size: 217804
+  timestamp: 1660346976440
+- kind: conda
+  name: yacs
+  version: 0.1.8
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/yacs-0.1.8-pyhd8ed1ab_0.tar.bz2
+  sha256: f8e6834ce20458239ee26f0a67e1163570d92819ff3292c07a3dcd453fb97847
+  md5: 193eeaf8f21582929a8955ac369752b3
+  depends:
+  - python >=3.6
+  - pyyaml
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/yacs?source=hash-mapping
+  size: 17659
+  timestamp: 1645706049083
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h7f98852_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 89141
+  timestamp: 1641346969816
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h8ffe710_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
+  sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
+  md5: adbfb9f45d1004a26763652246a33764
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 63274
+  timestamp: 1641347623319
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: h4ab18f5_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h4ab18f5_6.conda
+  sha256: 534824ea44939f3e59ca8ebb95e3ece6f50f9d2a0e69999fbc692311252ed6ac
+  md5: 559d338a4234c2ad6e676f460a093e67
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 h4ab18f5_6
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 92883
+  timestamp: 1716874088980
+- kind: conda
+  name: zstandard
+  version: 0.23.0
+  build: py39h08a7858_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py39h08a7858_1.conda
+  sha256: 76a45ef349517eaab1492f17f9c807ccbf1971961c6e90d454fbedbed7e257ad
+  md5: cd9fa334e11886738f17254f52210bc3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
+  size: 407017
+  timestamp: 1725305769438
+- kind: conda
+  name: zstandard
+  version: 0.23.0
+  build: py39h9bf74da_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py39h9bf74da_1.conda
+  sha256: 1446c0495565d6d7b364e0b2021d0309d21a34cb7d6bd19eced1a483fabfb915
+  md5: 5f1f0f75ebd24882ccf44d145939b104
+  depends:
+  - cffi >=1.11
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
+  size: 311116
+  timestamp: 1725305993710
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: h0ea2cb4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 349143
+  timestamp: 1714723445995
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: ha6fb4c9_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 554846
+  timestamp: 1714722996770

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,3 +33,24 @@ iopath = "*"
 setuptools = "*"
 pip = "*"
 cuda-toolkit = {version = "11.6.2", channel="nvidia/label/cuda-11.6.2"}
+
+[tasks.build-wheels]
+cmd = "python setup.py sdist bdist_wheel"
+
+[tasks.build-wheels.env]
+
+# Without this flag, pytorch3d setup.py will determine whether to build with
+# CUDA support or not based on host system's pytorch.cuda.is_available(), which
+# would be False on CI runners without CUDA hardware.
+FORCE_CUDA = "1"
+
+# When building on host system without actual GPU, we need to specify the CUDA
+# architectures to support. See this post:
+# https://github.com/pytorch/extension-cpp/issues/71#issuecomment-1183674660
+#
+# Note that the supported archs also depend on the CUDA toolkit version, and
+# the longer the list, the longer the build time.
+#
+# If you are building only locally on a machine with a GPU, you can comment out
+# this line. Though the resulting package will only support your GPU's arch.
+TORCH_CUDA_ARCH_LIST = "6.0;6.1;7.0;7.5;8.0;8.6+PTX"

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ platforms = ["win-64", "linux-64"]
 version = "0.7.6"
 
 [system-requirements]
-cuda = "11"
+#cuda = "11"
 
 [dependencies]
 python = ">=3.9, <3.10"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,28 @@
+[project]
+authors = ["FAIR"]
+description = "PyTorch3D is FAIR's library of reusable components for deep Learning with 3D data."
+name = "pytorch3d"
+channels = ["pytorch", "nvidia", "iopath", "conda-forge"]
+platforms = ["win-64", "linux-64"]
+version = "0.7.6"
+
+[system-requirements]
+cuda = "11"
+
+[dependencies]
+python = ">=3.9, <3.10"
+pytorch = {version = "1.13.1", channel="pytorch"}
+torchvision = {version = "0.14.1", channel="pytorch"}
+pytorch-cuda = {version = ">=11.6, <11.7", channel="pytorch"}
+mkl = "2024.0.0"
+fvcore = "0.1.5.post20221221"
+numpy = {version=">=1.20.0, <2.0", channel="conda-forge"}
+
+[pypi-dependencies]
+fvcore = "*"
+iopath = "*"
+
+[build-dependencies]
+setuptools = "*"
+pip = "*"
+cuda = {version = ">=11.6.2, <11.7", channel="nvidia"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,28 +1,35 @@
 [project]
+name = "pytorch3d"
+
 authors = ["FAIR"]
 description = "PyTorch3D is FAIR's library of reusable components for deep Learning with 3D data."
-name = "pytorch3d"
-channels = ["pytorch", "nvidia", "iopath", "conda-forge"]
-platforms = ["win-64", "linux-64"]
-version = "0.7.6"
 
-[system-requirements]
-#cuda = "11"
+# We put nvidia/label/* in front of nvidia so that strict channel priority
+# ensures cuda subcomponents of the same versions are picked up. We put
+# conda-forge in front of pytorch to pick up newer/better versions of
+# non-pytorch pacakages.
+channels = ["nvidia/label/cuda-11.6.2", "nvidia", "conda-forge", "pytorch", "iopath"]
+platforms = ["win-64", "linux-64"]
+
 
 [dependencies]
-python = ">=3.9, <3.10"
-pytorch = {version = "1.13.1", channel="pytorch"}
-torchvision = {version = "0.14.1", channel="pytorch"}
-pytorch-cuda = {version = ">=11.6, <11.7", channel="pytorch"}
+python = "3.9.*"
+pytorch = {version = "1.13.1.*", channel="pytorch"}
+torchvision = {version = "0.14.*", channel="pytorch"}
+pytorch-cuda = {version = "11.6.*", channel="pytorch"}
+
+# Version-specific fixups follow:
+
+# Newer version breaks compatibility with this pytorch release
 mkl = "2024.0.0"
-fvcore = "0.1.5.post20221221"
-numpy = {version=">=1.20.0, <2.0", channel="conda-forge"}
+
+# Prebuilt pytorch is linked against numpy 1.* ABI
+numpy = {version="<2.0", channel="conda-forge"}
 
 [pypi-dependencies]
-fvcore = "*"
 iopath = "*"
 
 [build-dependencies]
 setuptools = "*"
 pip = "*"
-cuda = {version = ">=11.6.2, <11.7", channel="nvidia"}
+cuda-toolkit = {version = "11.6.2", channel="nvidia/label/cuda-11.6.2"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -57,5 +57,4 @@ FORCE_CUDA = "1"
 #
 # If you are building only locally on a machine with a GPU, you can comment out
 # this line. Though the resulting package will only support your GPU's arch.
-#TORCH_CUDA_ARCH_LIST = "6.0;6.1;7.0;7.5;8.0;8.6+PTX"
-TORCH_CUDA_ARCH_LIST = "7.0+PTX" #1 arch to makes build faster
+TORCH_CUDA_ARCH_LIST = "6.0;6.1;7.0;7.5;8.0;8.6+PTX"

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,6 +32,9 @@ iopath = "*"
 [build-dependencies]
 setuptools = "*"
 pip = "*"
+
+# This pulls in the CUDA toolkit, so the host system does not need to have
+# preinstalled CUDA.
 cuda-toolkit = {version = "11.6.2", channel="nvidia/label/cuda-11.6.2"}
 
 [tasks.build-wheels]
@@ -39,9 +42,10 @@ cmd = "python setup.py sdist bdist_wheel"
 
 [tasks.build-wheels.env]
 
-# Without this flag, pytorch3d setup.py will determine whether to build with
-# CUDA support or not based on host system's pytorch.cuda.is_available(), which
-# would be False on CI runners without CUDA hardware.
+# This flag tells pytorch3d setup.py to always build with CUDA support, instead
+# of making that decision based on the host system's CUDA availability using
+# pytorch.cuda.is_available(), which would be False on CI runners without GPU
+# or CUDA drives.
 FORCE_CUDA = "1"
 
 # When building on host system without actual GPU, we need to specify the CUDA
@@ -53,4 +57,5 @@ FORCE_CUDA = "1"
 #
 # If you are building only locally on a machine with a GPU, you can comment out
 # this line. Though the resulting package will only support your GPU's arch.
-TORCH_CUDA_ARCH_LIST = "6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+#TORCH_CUDA_ARCH_LIST = "6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+TORCH_CUDA_ARCH_LIST = "7.0+PTX" #1 arch to makes build faster


### PR DESCRIPTION
This PR adds the pixi configuration and lockfiles for building PyTorch3D v0.7.6 with CUDA support on Windows. The included GitHub action will then automatically build Python wheels and release them when an appropriately formatted tag is pushed. The current build environment uses Python 3.9, PyTorch 1.13, and CUDA 11.6 on Windows. The same pixi configuration can be easily adjusted to target other Python, PyTorch, CUDA versions, as well as the Linux platform. I have succeeded built PyTorch3D v0.7.7 with Python 3.12, PyTorch 2.3, and CUDA 12.1 on both Windows and Linux after minimal changes.

Closes urusgraphics/worldtree#768